### PR TITLE
Hotfix some broken routes

### DIFF
--- a/app/components/map-from-id.js
+++ b/app/components/map-from-id.js
@@ -24,7 +24,6 @@ function buildPaint({ property, colors, breaks, opacity }) {
 
   colorArray.push('#FFF')
 
-  console.log('PAINT', paint)
   return paint;
 }
 
@@ -37,10 +36,8 @@ export default Component.extend({
   @computed('mapConfig.layers')
   builtLayers(layers) {
     return layers.map(layer => {
-      console.log('layer', layer)
       if (layer.type === 'choropleth') {
         const { id, source, paintConfig } = layer;
-        console.log('here', id, source)
         return {
           id,
           type: 'fill',
@@ -56,7 +53,6 @@ export default Component.extend({
 
   actions: {
     handleMapLoad(map) {
-      console.log('mapConfig', this.get('mapConfig'))
       const sources = this.get('mapConfig.sources');
 
       if (window) {

--- a/app/routes/map.js
+++ b/app/routes/map.js
@@ -7,26 +7,14 @@ const { Promise } = Ember.RSVP;
 
 export default Route.extend({
   model({ slug }) {
-    console.log('MODEL')
     const { maps = [] } = this
       .modelFor('application');
-
-
-
-    const mapConfig = maps.findBy('slug', slug).map[0];
-
-    console.log('mapconfig', mapConfig)
-
-
+    const [mapConfig] = maps.findBy('slug', slug).map;
     const { sources } = mapConfig;
 
-    console.log('sources', sources)
-
-
-    const cartoSourcePromises = Object.keys(sources)
+    const cartoSourcePromises = Object.keys(sources || {})
       .filter(key => sources[key].type === 'cartovector')
       .map((key) => {
-        console.log(key)
         const source = sources[key];
         const { minzoom = 0 } = source;
 
@@ -38,8 +26,6 @@ export default Route.extend({
             minzoom,
           }));
       });
-
-    // mapConfig.sources = Promise.all(cartoSourcePromises)
 
     return Promise.all(cartoSourcePromises)
       .then(cartoPromises => {

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -1,5 +1,3 @@
-{{log 'MAPCONFIG' (await mapConfig.sources)}}
-
 {{#jane-maps
   id='map'
   initOptions=(hash style='mapbox://styles/mapbox/light-v9'
@@ -11,8 +9,6 @@
 
 
   {{#each builtLayers as |layer| }}
-    {{log layer}}
-
     {{map.layer layer=layer before='waterway-label'}}
   {{/each}}
 

--- a/app/templates/map.hbs
+++ b/app/templates/map.hbs
@@ -1,5 +1,3 @@
-
-{{log "MODEL" model}}
 {{map-from-id
   id=model.map
   narrativeVisible=narrativeVisible
@@ -8,12 +6,14 @@
 }}
 
 {{#if narrativeVisible}}
-<a {{action 'toggleNarrative'}} class="narrative-toggle"><span>{{fa-icon 'times'}}</span></a>
-<div class="cell large-5 xlarge-4 narrative-container">
-  <h1 class="header-xlarge narrative-title">{{model.title}}</h1>
-  {{md-text text = model.content}}
-  {{outlet}}
-</div>
+  <a {{action 'toggleNarrative'}} class="narrative-toggle">
+    <span>{{fa-icon 'times'}}</span>
+  </a>
+  <div class="cell large-5 xlarge-4 narrative-container">
+    <h1 class="header-xlarge narrative-title">{{model.title}}</h1>
+    {{md-text text = model.content}}
+    {{outlet}}
+  </div>
 {{/if}}
 
 {{outlet}}


### PR DESCRIPTION
This fixes some things with the routes, but only one route works for now until the other map layers and sources are fixed.

The map route wasn't set up to gracefully handle undefined layers or sources in the map configuration - this adds some defaults to prevent immediate issues. `map-by-id` component is the same. In general we should try to have graceful handling for undefined properties.