### PR TITLE
HOTFIX: bad dropdown markup

### DIFF
--- a/app/styles/_settings.scss
+++ b/app/styles/_settings.scss
@@ -389,7 +389,7 @@ $dropdown-sizes: (
 // -----------------
 
 $dropdownmenu-arrows: true;
-$dropdownmenu-arrow-color: $anchor-color;
+$dropdownmenu-arrow-color: $dcp-yellow;
 $dropdownmenu-arrow-size: 6px;
 $dropdownmenu-arrow-padding: 1.5rem;
 $dropdownmenu-min-width: 200px;
@@ -399,7 +399,7 @@ $dropdownmenu-padding: $global-menu-padding;
 $dropdownmenu-nested-margin: 0;
 $dropdownmenu-submenu-padding: $dropdownmenu-padding;
 $dropdownmenu-border: 1px solid $medium-gray;
-$dropdown-menu-item-color-active: get-color(primary);
+$dropdown-menu-item-color-active: $black;
 $dropdown-menu-item-background-active: transparent;
 
 // 19. Flexbox Utilities

--- a/app/styles/modules/_m-site-header.scss
+++ b/app/styles/modules/_m-site-header.scss
@@ -60,6 +60,19 @@ $logo-height-medium: rem-calc(36);
         color: $black;
       }
     }
+
+    .is-dropdown-submenu {
+      box-shadow: 0 2px 0 2px rgba(0,0,0,0.1);
+
+      li:not(:first-child) {
+        border-top: 1px solid lighten($medium-gray, 10%);
+      }
+
+      a {
+        padding: rem-calc(10) rem-calc(16);
+        font-size: rem-calc(12);
+      }
+    }
   }
 
   .responsive-nav-toggler {

--- a/app/templates/components/site-header.hbs
+++ b/app/templates/components/site-header.hbs
@@ -10,7 +10,7 @@
     </div>
     <div id="responsive-menu" class="cell large-shrink {{if closed 'show-for-large'}} hide-for-print">
       <nav role="navigation">
-        {{#zf-dropdown-menu class="horizontal"}}
+        {{#zf-dropdown-menu class="vertical large-horizontal"}}
           {{#each-in (group-by "category" model.maps) as |category maps|}}
             <li>
               <a>{{category}}</a>

--- a/app/templates/components/site-header.hbs
+++ b/app/templates/components/site-header.hbs
@@ -10,22 +10,20 @@
     </div>
     <div id="responsive-menu" class="cell large-shrink {{if closed 'show-for-large'}} hide-for-print">
       <nav role="navigation">
-        <ul class="dropdown menu">
+        {{#zf-dropdown-menu class="horizontal"}}
           {{#each-in (group-by "category" model.maps) as |category maps|}}
-            {{#zf-dropdown-menu class="horizontal"}}
-              <li>
-                <a>{{category}}</a>
-                <ul class="menu">
-                  {{#each maps as |map|}}
-                    <li>
-                      {{link-to map.title 'map' map.category map.slug}}
-                    </li>
-                  {{/each}}
-                </ul>
-              </li>
-            {{/zf-dropdown-menu}}
+            <li>
+              <a>{{category}}</a>
+              <ul class="menu">
+                {{#each maps as |map|}}
+                  <li>
+                    {{link-to map.title 'map' map.category map.slug}}
+                  </li>
+                {{/each}}
+              </ul>
+            </li>
           {{/each-in}}
-        </ul>
+        {{/zf-dropdown-menu}}
       </nav>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes an issue with the `site-header`'s dropdown menu. 
- There was an unnecessary `<ul>` wrapping the `{{zf-dropdown-menu}}` component. Removed it.
- The `{{each}}` was creating multiple menus, so that more than one could be open at a time and they'd overlap. Moved the loop inside the dropdown component. 
- Added a bit of styling to the dropdown menus. 