### PR TITLE
add sidebar.content, sidebar.button to page layout, config

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -97,7 +97,12 @@ body {
 // Static Pages
 // --------------------------------------------------
 .page-container {
-  padding: $global-margin $global-margin $global-margin*2;
+  padding-top: $global-margin;
+  padding-bottom: $global-margin*4;
+}
+
+.page-sidebar {
+  padding-top: rem-calc(10);
 }
 
 // Narratives

--- a/app/templates/components/site-header.hbs
+++ b/app/templates/components/site-header.hbs
@@ -11,6 +11,7 @@
     <div id="responsive-menu" class="cell large-shrink {{if closed 'show-for-large'}} hide-for-print">
       <nav role="navigation">
         {{#zf-dropdown-menu class="vertical large-horizontal"}}
+
           {{#each-in (group-by "category" filteredMapLinks) as |category maps|}}
             <li>
               <a>{{category}}</a>
@@ -23,6 +24,11 @@
               </ul>
             </li>
           {{/each-in}}
+
+          {{#each model.pages as |page|}}
+            <li>{{link-to page.menutitle 'page' page.slug}}</li>
+          {{/each}}
+
         {{/zf-dropdown-menu}}
       </nav>
     </div>

--- a/app/templates/page.hbs
+++ b/app/templates/page.hbs
@@ -1,7 +1,34 @@
-<div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2 page-container">
+<div class="cell">
 
-  <h1 class="header-xlarge">{{model.title}}</h1>
-  {{md-text text = model.content}}
+  <div class="page-container grid-x grid-padding-x">
+
+    <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2">
+      <h1>{{model.title}}</h1>
+    </div>
+
+    {{#if (or model.sidebar.content model.sidebar.button)}}
+
+      <div class="cell large-6 large-offset-1 xlarge-5 xlarge-offset-2">
+        {{md-text text = model.content}}
+      </div>
+
+      <div class="cell page-sidebar large-4 xlarge-3">
+        {{md-text text = model.sidebar.content}}
+        {{#if model.sidebar.button}}
+          <a href="{{model.sidebar.button}}" class="button">Download All Data <small>(CSV)</small></a>
+        {{/if}}
+      </div>
+
+    {{else}}
+
+      <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2">
+        {{md-text text = model.content}}
+      </div>
+
+    {{/if}}
+
+  </div>
+
   {{outlet}}
 
 </div>

--- a/app/templates/page.hbs
+++ b/app/templates/page.hbs
@@ -15,7 +15,7 @@
       <div class="cell page-sidebar large-4 xlarge-3">
         {{md-text text = model.sidebar.content}}
         {{#if model.sidebar.button}}
-          <a href="{{model.sidebar.button}}" class="button">Download All Data <small>(CSV)</small></a>
+          <a href="{{model.sidebar.button}}" class="button">{{if model.sidebar.buttontext model.sidebar.buttontext model.sidebar.button}}</a>
         {{/if}}
       </div>
 

--- a/cms/meta.yaml
+++ b/cms/meta.yaml
@@ -1,4 +1,8 @@
 orderings:
+
+  pages:
+    - id: about
+
   maps:
     - id: housing-1
       hasNarrative: true

--- a/cms/pages/about.yaml
+++ b/cms/pages/about.yaml
@@ -1,4 +1,23 @@
 slug: about
-title: About
+title: About NYC Metro Mapper
 content: |
+  ## Lorem ipsum dolor
+
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+  ### Data Sourcing
+
+  Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+  - [Link to source data](http://example.org/)
+  - [Link to source data](http://example.org/)
+  - [Link to source data](http://example.org/)
+  - [Link to source data](http://example.org/)
+  - [Link to source data](http://example.org/)
+
+sidebar:
+  content: |
+    ### Get the data...
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+  button: http://example.org/

--- a/cms/pages/about.yaml
+++ b/cms/pages/about.yaml
@@ -1,5 +1,6 @@
 slug: about
 title: About NYC Metro Mapper
+menutitle: About
 content: |
   ## Lorem ipsum dolor
 

--- a/cms/pages/about.yaml
+++ b/cms/pages/about.yaml
@@ -21,3 +21,4 @@ sidebar:
     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
   button: http://example.org/
+  buttontext: Download All Data (CSV)


### PR DESCRIPTION
This PR adds two new parameters to the About page config: `sidebar.content` and `sidebar.button`. The page template has been updated to conditionally add a sidebar if either of these exist. The About page config has also been updated with placeholder information for data sourcing (@daragoldberg to provide final copy). Adds `orderings.pages` to `meta.yaml` and puts them in the header menu.

Closes #41. 