### PR TITLE
All maps (except intro) in header menu

### DIFF
--- a/app/components/site-header.js
+++ b/app/components/site-header.js
@@ -11,6 +11,6 @@ export default Component.extend({
 
   @computed('model.maps')
   filteredMapLinks(maps) {
-    return maps.filter(map => map.hasNarrative);
+    return maps.filter(map => !map.hideFromMenu);
   },
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,7 +1,5 @@
 {{site-header model=model}}
 
-{{log model.maps}}
-
 <div class="site-main grid-x">
     {{outlet}}
 </div>

--- a/app/templates/map.hbs
+++ b/app/templates/map.hbs
@@ -5,8 +5,6 @@
   mapConfig=model.map
 }}
 
-{{log previousNarrative}}
-
 {{#if narrativeVisible}}
   <a {{action 'toggleNarrative'}} class="narrative-toggle">
     <span>{{fa-icon 'times'}}</span>

--- a/cms/maps/introduction.yaml
+++ b/cms/maps/introduction.yaml
@@ -1,0 +1,11 @@
+slug: intro
+category: welcome
+title: Introduction
+content: |
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+map:
+  sources: []
+  layers: []

--- a/cms/meta.yaml
+++ b/cms/meta.yaml
@@ -1,5 +1,9 @@
 orderings:
   maps:
+    - id: intro
+      hasNarrative: true
+      hideFromMenu: true
+
     - id: housing-1
       hasNarrative: true
 
@@ -20,3 +24,6 @@ orderings:
 
     - id: population-change
       hasNarrative: true
+
+    - id: population-change-subregion
+      hasNarrative: false


### PR DESCRIPTION
This PR: 

- Adds intro map config
- Defines the first map as `intro` so that the app defaults to showing it on the landing page (we might want to revisit its category and slug)
- Filters the map menu by `hideFromMenu` instead of `hasNarrative`
- Adds `population-change-subregion` to the map orderings _(Note: If there are map configs that are not included in the orderings, the menu may not order properly.)_
- Nixes a few stray console logs

Closes #54. 