### PR TITLE
Feature/65 default geography level

### DIFF
--- a/app/components/map-from-id.js
+++ b/app/components/map-from-id.js
@@ -9,6 +9,7 @@ import getPopupSQL from '../utils/get-popup-sql';
 export default Component.extend({
   classNameBindings: ['narrativeVisible:narrative-visible'],
   classNames: 'map-container cell large-auto',
+  toggledGeographyLevel: null,
 
   // noop for passed context
   toggleNarrative() {},
@@ -23,6 +24,15 @@ export default Component.extend({
     closeOnClick: false,
   }),
 
+  @computed('mapConfig', 'toggledGeographyLevel')
+  geographyLevel(defaultGeographyLevel = 'county', toggledGeographyLevel = null) {
+    if (toggledGeographyLevel) {
+      return toggledGeographyLevel;
+    }
+    return get(defaultGeographyLevel, 'defaultGeographyLevel');
+  },
+
+  // TODO: Don't use firstLayer. Nix this when making legends update on geographyLevel change.
   @computed('mapConfig.layers')
   layerTitle([firstLayer = {}] = []) {
     return get(firstLayer, 'title');
@@ -75,6 +85,8 @@ export default Component.extend({
     if (!map) return;
     const sources = this.get('mapConfig.sources');
     const popup = this.get('popup');
+
+    this.set('toggledGeographyLevel', null);
 
     sources.forEach((source) => {
       if (!map.getSource(source.id)) {
@@ -139,6 +151,10 @@ export default Component.extend({
       } else {
         popup.remove();
       }
+    },
+
+    handleGeographyLevelToggle(geog) {
+      this.set('toggledGeographyLevel', geog);
     },
   },
 });

--- a/app/controllers/map.js
+++ b/app/controllers/map.js
@@ -13,7 +13,6 @@ export default Controller.extend({
 
   application: inject(),
   narrativeVisible: true,
-  geographyLevel: 'county',
 
   @computed('application.model.maps', 'model.slug')
   previousNarrative(maps, currentSlug) {
@@ -38,9 +37,6 @@ export default Controller.extend({
       next(function() {
         window.dispatchEvent(new Event('resize'));
       });
-    },
-    handleGeographyLevelToggle(geog) {
-      this.set('geographyLevel', geog);
     },
   },
 });

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -17,12 +17,15 @@
     {{map.layer layer=highlightedFeatureLayer before='waterway-label'}}
   {{/if}}
 
-  {{yield (hash
-    breaks=breaks
-    layerTitle=layerTitle
-    geographyLevel=geographyLevel
-    map-utility-box=(component 'map-utility-box' mapConfig=mapConfig toggles=mapConfig.toggles)
-    mapboxGl=map)}}
+  {{!-- Legends --}}
+  {{map-utility-box
+    mapConfig=mapConfig
+    toggles=mapConfig.toggles
+    handleGeographyLevelToggle=(action 'handleGeographyLevelToggle')
+    layerTitle=map.layerTitle
+    geographyLevel=geographyLevel}}
+
+  {{yield (hash mapboxGl=map)}}
 
   {{map.on 'mousemove' (action 'handleMouseMove')}}
   {{map.on 'click' (action 'handleMouseClick')}}

--- a/app/templates/map.hbs
+++ b/app/templates/map.hbs
@@ -1,16 +1,9 @@
 {{#map-from-id
   narrativeVisible=narrativeVisible
   toggleNarrative=(action 'toggleNarrative')
-  geographyLevel=geographyLevel
   mapConfig=model.map
   as |map|
 }}
-
-  {{!-- Legends and Breaks --}}
-  {{map.map-utility-box
-    handleGeographyLevelToggle=(action 'handleGeographyLevelToggle')
-    layerTitle=map.layerTitle
-    geographyLevel=geographyLevel}}
 
   {{supporting-layers map=map.mapboxGl}}
 {{/map-from-id}}

--- a/cms/maps/housing-total-units.yaml
+++ b/cms/maps/housing-total-units.yaml
@@ -18,6 +18,8 @@ map:
   - layerId: total-units-municipality
     type: municipality
 
+  defaultGeographyLevel: municipality
+
   sources:
   - id: total-units
     type: cartovector

--- a/cms/maps/housing-units-permitted.yaml
+++ b/cms/maps/housing-units-permitted.yaml
@@ -18,6 +18,8 @@ map:
   - layerId: units-permitted-municipality
     type: municipality
 
+  defaultGeographyLevel: county
+
   sources:
   - id: units-permitted
     type: cartovector

--- a/cms/maps/jobs-private-employment-change.yaml
+++ b/cms/maps/jobs-private-employment-change.yaml
@@ -16,6 +16,9 @@ map:
   - layerId: private-employment-change-county
     type: county
 
+  defaultGeographyLevel: county
+  # TODO: Confirm defaultGeographyLevel; it's not defined in spreadsheet
+
   sources:
   - id: private-employment-change
     type: cartovector

--- a/cms/maps/jobs-total-employment.yaml
+++ b/cms/maps/jobs-total-employment.yaml
@@ -18,6 +18,8 @@ map:
   - layerId: total-employment-municipality
     type: municipality
 
+  defaultGeographyLevel: subregion
+
   sources:
   - id: total-employment
     type: cartovector

--- a/cms/maps/people-foreign-born.yaml
+++ b/cms/maps/people-foreign-born.yaml
@@ -18,6 +18,8 @@ map:
   - layerId: foreign-born-municipality
     type: municipality
 
+  defaultGeographyLevel: municipality
+
   sources:
   - id: foreign-born
     type: cartovector

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -15,8 +15,11 @@ map:
     type: subregion
   - layerId: net-population-change-county
     type: county
-  - layerId: net-population-change-municipality
-    type: municipality
+  # - layerId: net-population-change-municipality
+  #   type: municipality
+
+  defaultGeographyLevel: county
+  # TODO: change defaultGeographyLevel to municipality once dot density is in
 
   sources:
   - id: net-population-change

--- a/cms/maps/people-population-change.yaml
+++ b/cms/maps/people-population-change.yaml
@@ -16,6 +16,8 @@ map:
   - layerId: population-change-county
     type: county
 
+  defaultGeographyLevel: county
+
   sources:
   - id: population-change
     type: cartovector

--- a/cms/maps/people-population-density.yaml
+++ b/cms/maps/people-population-density.yaml
@@ -18,6 +18,8 @@ map:
   - layerId: population-density-municipality
     type: municipality
 
+  defaultGeographyLevel: municipality
+
   sources:
   - id: population-density
     type: cartovector

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -16,6 +16,9 @@ map:
   - layerId: prime-labor-force-gain-county
     type: county
 
+  defaultGeographyLevel: county
+  # TODO: change defaultGeographyLevel to municipality once dot density is in
+
   sources:
   - id: prime-labor-force-gain
     type: cartovector
@@ -72,3 +75,4 @@ map:
       - 2500
       - 15000
       - 75000
+  # TODO: add dot density layer config

--- a/cms/maps/people-total-population.yaml
+++ b/cms/maps/people-total-population.yaml
@@ -18,6 +18,8 @@ map:
   - layerId: total-population-municipality
     type: municipality
 
+  defaultGeographyLevel: subregion
+
   sources:
   - id: total-population
     type: cartovector


### PR DESCRIPTION
This PR… 
- Adds `defaultGeographyLevel` to each map.yaml _(I left `TODO` notes where configs are wrong/incomplete)_
- Moves the `geographyLevel` property from the `map` controller to the `map-from-id` component _(The map route doesn't need to know about geo level)_
- On route change, maps ignore the selected geog level and use the `defaultGeographyLevel` computed property to show the right default layers
- Moves the legend component (`map-utility-box`) from `map.hbs` into `map-from-id.hbs`

Closes #65 