### PR TITLE
Cw bugfixes

### DIFF
--- a/app/components/geometry-toggle.js
+++ b/app/components/geometry-toggle.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -4,16 +4,21 @@ import numeral from 'numeral';
 
 export default Component.extend({
   handleGeographyLevelToggle() {},
+  currentLayerConfig: {},
   mapConfig: {},
 
-  @computed('mapConfig')
-  breaks(mapConfig) {
+  // TODO: Don't use firstLayer. Nix this when making legends update on geographyLevel change.
+  @computed('currentLayerConfig')
+  layerTitle({ title = '' } = {}) {
+    return title;
+  },
+
+  @computed('currentLayerConfig', 'isPercent')
+  breaks(layerConfig, isPercent) {
     // return an array of objects, each with a display-ready range and color
-    const { layers = [] } = mapConfig;
-    const [firstLayer = {}] = layers;
-    const { paintConfig: config = {} } = firstLayer;
+    const { paintConfig: config = {} } = layerConfig || {};
     const { breaks = [], colors = [] } = config;
-    const { isPercent } = mapConfig;
+
     const format = (value) => { // eslint-disable-line
       return isPercent ? numeral(value).format('0,0%') : numeral(value).format('0,0');
     };

--- a/app/components/map-from-id.js
+++ b/app/components/map-from-id.js
@@ -32,10 +32,13 @@ export default Component.extend({
     return get(defaultGeographyLevel, 'defaultGeographyLevel');
   },
 
-  // TODO: Don't use firstLayer. Nix this when making legends update on geographyLevel change.
-  @computed('mapConfig.layers')
-  layerTitle([firstLayer = {}] = []) {
-    return get(firstLayer, 'title');
+  @computed('mapConfig', 'geographyLevel')
+  currentLayerConfig(mapConfig, geographyLevel) {
+    const { toggles = [] } = mapConfig;
+    const foundLayer = toggles.find(d => d.type === geographyLevel) || {};
+    const { layerId: currentLayerId } = foundLayer;
+
+    return mapConfig.layers.find(d => d.id === currentLayerId);
   },
 
   @computed('highlightedFeature')

--- a/app/components/map-utility-box.js
+++ b/app/components/map-utility-box.js
@@ -23,8 +23,8 @@ export default Component.extend({
     for (let i = breaks.length; i >= 0; i -= 1) {
       if (i === breaks.length) {
         breaksArray.push({
-          label: `${format(breaks[breaks.length - 2])} or more`,
-          color: colors[breaks.length - 1],
+          label: `${format(breaks[breaks.length - 1])} or more`,
+          color: colors[breaks.length],
         });
         continue; // eslint-disable-line
       }

--- a/app/templates/components/geometry-toggle.hbs
+++ b/app/templates/components/geometry-toggle.hbs
@@ -1,13 +1,3 @@
-<div class="legend">
-  <h5 class="legend-title">{{layerTitle}}</h5>
-  {{#each breaks as |break|}}
-    <div class="legend-item">
-      <span class="legend-color" style="color:{{break.color}};">{{fa-icon 'square'}}</span>
-      {{break.label}}
-    </div>
-  {{/each}}
-</div>
-
 <ul class="menu geography-selector">
   {{#each toggles as |toggle|}}
     <li class="{{if (eq geographyLevel toggle.type) 'active'}} explode-block toggle-list-item">
@@ -17,3 +7,4 @@
     </li>
   {{/each}}
 </ul>
+{{yield}}

--- a/app/templates/components/legend-box.hbs
+++ b/app/templates/components/legend-box.hbs
@@ -1,0 +1,11 @@
+{{#unless (eq layerTitle '')}}
+  <div class="legend">
+    <h5 class="legend-title">{{layerTitle}}</h5>
+    {{#each breaks as |break|}}
+      <div class="legend-item">
+        <span class="legend-color" style="color:{{break.color}};">{{fa-icon 'square'}}</span>
+        {{break.label}}
+      </div>
+    {{/each}}
+  </div>
+{{/unless}}

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -22,7 +22,7 @@
     mapConfig=mapConfig
     toggles=mapConfig.toggles
     handleGeographyLevelToggle=(action 'handleGeographyLevelToggle')
-    layerTitle=map.layerTitle
+    layerTitle=layerTitle
     geographyLevel=geographyLevel}}
 
   {{yield (hash mapboxGl=map)}}

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -18,12 +18,18 @@
   {{/if}}
 
   {{!-- Legends --}}
-  {{map-utility-box
-    mapConfig=mapConfig
-    toggles=mapConfig.toggles
+  {{legend-box
+    currentLayerConfig=currentLayerConfig
+    isPercent=mapConfig.map.isPercent
+  }}
+
+  {{!-- Geometry toggle --}}
+  {{geometry-toggle
+    geographyLevel=geographyLevel
     handleGeographyLevelToggle=(action 'handleGeographyLevelToggle')
-    layerTitle=layerTitle
-    geographyLevel=geographyLevel}}
+    toggles=mapConfig.toggles
+  }}
+
 
   {{yield (hash mapboxGl=map)}}
 

--- a/app/utils/get-popup-sql.js
+++ b/app/utils/get-popup-sql.js
@@ -11,7 +11,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
   const SQLArray = [];
 
   SQLArray.push(`
-    SELECT 'region' as geomtype, 'NYC region' as name, 100000 as value
+    SELECT 'region' as geomtype, 'NYC region' as name, XXX,XXX as value
   `);
 
   if (getPopupValue('subregion')) {

--- a/app/utils/get-popup-sql.js
+++ b/app/utils/get-popup-sql.js
@@ -11,7 +11,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
   const SQLArray = [];
 
   SQLArray.push(`
-    SELECT 'region' as geomtype, 'NYC region' as name, XXX,XXX as value
+    SELECT 'region' as geomtype, 'NYC region' as name, 100000 as value
   `);
 
   if (getPopupValue('subregion')) {

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -1,0 +1,58 @@
+# Housing
+# ----------
+slug: renter-owner
+category: Housing
+categorySlug: housing
+title: "The region is roughly split between owner- (XX%) and renter-occupied (XX%) housing units"
+menuTitle: "Housing Units by Renter vs. Owner, 2012-2016 Avg"
+content: |
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+source: This maps show data from some source.
+
+map:
+  toggles:
+  - layerId: renter-owner-municipality
+    type: municipality
+
+  defaultGeographyLevel: municipality
+
+  sources:
+  - id: renter-owner
+    type: cartovector
+    source-layers:
+    - id: renter-owner-municipality
+      sql: SELECT the_geom_webmercator, random_value FROM region_tenure_dotdensity_v0
+
+  popupValues:
+  - id: subregion
+    value: houa16
+  - id: county
+    value: houa16
+  - id: municipality
+    value: hou16
+
+  isPercent: false
+
+  layers:
+  - id: renter-owner-municipality
+    title: "Housing Units by Renter vs. Owner, 2012-2016 Avg"
+    type: circle
+    source: renter-owner
+    source-layer: renter-owner-municipality
+    paint:
+      circle-color:
+      - match
+      - - get
+        - random_value
+      - "own"
+      - "#fc8d59"
+      - "rent"
+      - "#91bfdb"
+      - "#FFFFFF"
+      circle-radius:
+        stops:
+        - - 7
+          - 1.5
+        - - 11
+          - 2
+      circle-opacity: 0.9

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -15,8 +15,8 @@ map:
     type: subregion
   - layerId: net-population-change-county
     type: county
-  # - layerId: net-population-change-municipality
-  #   type: municipality
+  - layerId: net-population-change-municipality
+    type: municipality
 
   defaultGeographyLevel: county
   # TODO: change defaultGeographyLevel to municipality once dot density is in
@@ -30,7 +30,7 @@ map:
     - id: net-population-change-county
       sql: SELECT the_geom_webmercator, geoid, pop1016 as value FROM region_county_v0
     - id: net-population-change-municipality
-      sql: SELECT the_geom_webmercator, geoid, popa1016 as value FROM region_municipality_v0
+      sql: SELECT the_geom_webmercator, popa1016, popa1016si as value FROM region_popa1016_dotdensity_v0
 
   popupValues:
   - id: subregion
@@ -81,3 +81,23 @@ map:
       - 15000
       - 50000
   # TODO: add dot density layer config
+  - id: net-population-change-municipality
+    title: "Net Population Change, 2010 - 2016"
+    type: circle
+    source: net-population-change
+    source-layer: net-population-change-municipality
+    paint:
+      circle-color:
+      - step
+      - - get
+        - popa1016
+      - "#ff7900"
+      - 0
+      - "#00aacc"
+      circle-radius:
+        stops:
+        - - 7
+          - 1.5
+        - - 11
+          - 2
+      circle-opacity: 0.6

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -4,7 +4,7 @@ slug: prime-labor-force-gain
 category: People
 categorySlug: people
 title: "NYC gain of prime labor force (participants age 25 to 54) outpaced the regional net gain from 2000-2016."
-menuTitle: "Net Population Change, 2010 - 2016"
+menuTitle: "Prime Labor Force Change, 2000-2016"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.
@@ -15,9 +15,10 @@ map:
     type: subregion
   - layerId: prime-labor-force-gain-county
     type: county
+  - layerId: prime-labor-force-gain-municipality
+    type: municipality
 
-  defaultGeographyLevel: county
-  # TODO: change defaultGeographyLevel to municipality once dot density is in
+  defaultGeographyLevel: municipality
 
   sources:
   - id: prime-labor-force-gain
@@ -27,6 +28,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, lfpw0016 as value FROM region_subregion_v0
     - id: prime-labor-force-gain-county
       sql: SELECT the_geom_webmercator, geoid, lfpw0016 as value FROM region_county_v0
+    - id: prime-labor-force-gain-municipality
+      sql: SELECT the_geom_webmercator, lfpw0016, lfpw0016si as value FROM region_lfpw0016_dotdensity_v0
 
   popupValues:
   - id: subregion
@@ -38,7 +41,7 @@ map:
 
   layers:
   - id: prime-labor-force-gain-subregion
-    title: "Net Population Change, 2010 - 2016"
+    title: "Prime Labor Force Change, 2000-2016"
     type: choropleth
     source: prime-labor-force-gain
     source-layer: prime-labor-force-gain-subregion
@@ -56,7 +59,7 @@ map:
       - 10000
       - 100000
   - id: prime-labor-force-gain-county
-    title: "Net Population Change, 2010 - 2016"
+    title: "Prime Labor Force Change, 2000-2016"
     type: choropleth
     source: prime-labor-force-gain
     source-layer: prime-labor-force-gain-county
@@ -75,4 +78,23 @@ map:
       - 2500
       - 15000
       - 75000
-  # TODO: add dot density layer config
+  - id: prime-labor-force-gain-municipality
+    title: "Prime Labor Force Change, 2000-2016"
+    type: circle
+    source: prime-labor-force-gain
+    source-layer: prime-labor-force-gain-municipality
+    paint:
+      circle-color:
+      - step
+      - - get
+        - lfpw0016
+      - "#ff7900"
+      - 0
+      - "#00aacc"
+      circle-radius:
+        stops:
+        - - 7
+          - 1.5
+        - - 11
+          - 2
+      circle-opacity: 0.6

--- a/cms/meta.yaml
+++ b/cms/meta.yaml
@@ -27,6 +27,8 @@ orderings:
       hasNarrative: true
     - id: units-permitted
       hasNarrative: true
+    - id: renter-owner
+      hasNarrative: true
 
     # Jobs
     - id: total-employment

--- a/tests/integration/components/geometry-toggle-test.js
+++ b/tests/integration/components/geometry-toggle-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('geometry-toggle', 'Integration | Component | geometry toggle', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{geometry-toggle}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#geometry-toggle}}
+      template block text
+    {{/geometry-toggle}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/legend-box.js
+++ b/tests/integration/components/legend-box.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('map-utility-box', 'Integration | Component | map utility box', {
+moduleForComponent('legend-box', 'Integration | Component | map utility box', {
   integration: true
 });
 
@@ -9,7 +9,7 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{map-utility-box}}`);
+  this.render(hbs`{{legend-box}}`);
 
   assert.equal(!!this.$(), true);
 });
@@ -27,7 +27,7 @@ test('it displays legend', function(assert) {
   ];
 
   this.set('breaks', breaks);
-  this.render(hbs`{{map-utility-box breaks=breaks}}`);
+  this.render(hbs`{{legend-box breaks=breaks}}`);
 
   assert.equal(this.$('.legend-item').length, 6);
 });
@@ -43,7 +43,7 @@ test('it displays toggle from data', function(assert) {
   ];
 
   this.set('toggles', toggles);
-  this.render(hbs`{{map-utility-box toggles=toggles}}`);
+  this.render(hbs`{{legend-box toggles=toggles}}`);
 
   assert.equal(this.$('.toggle-list-item').length, 3);
 });


### PR DESCRIPTION
This PR:

- Splits the geometry toggle bar and the legend box into different components (formerly both were in map-info-box)
- Refactors legend-box to take a simpler input, and gets the legend titles working again. Closes #62
- Gets legends to update as the geography level changes (they now match the maps properly) #61
- Refactor of existing code
- Updates the configs to include several first-pass dot density maps Closes #8
- Fixes duplicate break in choropleth legends. Closes #68
