### PR TITLE
use didReceiveAttrs to determine whether to reset geom level

### DIFF
--- a/app/components/map-from-id.js
+++ b/app/components/map-from-id.js
@@ -83,13 +83,22 @@ export default Component.extend({
       .filter(layer => !hiddenLayersIDs.some(layerId => (layer.id === layerId || layer.id === `${layerId}-line`)));
   },
 
+  didReceiveAttrs() {
+    const previousNarrativeVisible = this.get('previousNarrativeVisible');
+    const narrativeVisible = this.get('narrativeVisible');
+
+    if (previousNarrativeVisible === narrativeVisible) {
+      this.set('toggledGeographyLevel', null);
+    }
+
+    this.set('previousNarrativeVisible', narrativeVisible);
+  },
+
   didUpdateAttrs() {
     const map = this.get('map');
     if (!map) return;
     const sources = this.get('mapConfig.sources');
     const popup = this.get('popup');
-
-    this.set('toggledGeographyLevel', null);
 
     sources.forEach((source) => {
       if (!map.getSource(source.id)) {


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR uses the `didReceiveAttrs()` hook in `map-from-id` to conditionally reset the selected geometry level... we want it to reset only when navigating between maps, not when opening and closing the info pane.

Closes #81
