### PR TITLE
70 dot density legends

### DIFF
--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -2,6 +2,48 @@ import Component from '@ember/component';
 import { computed } from 'ember-decorators/object';
 import numeral from 'numeral';
 
+function getChoroplethRows(layerConfig, isPercent, isChangeMeasurement) {
+  // return an array of objects, each with a display-ready range and color
+  const { paintConfig: config = {} } = layerConfig || {};
+  const { breaks = [], colors = [] } = config;
+  const format = (value) => { // eslint-disable-line
+
+    let formatter = '0.0a';
+    if (isPercent) formatter = '0.0%';
+    if (isChangeMeasurement) formatter = '+0.0';
+    if (isPercent && isChangeMeasurement) formatter = '+0.0%';
+
+    return numeral(value).format(formatter);
+  };
+
+  const breaksArray = [];
+
+  for (let i = breaks.length; i >= 0; i -= 1) {
+    if (i === breaks.length) {
+      breaksArray.push({
+        label: `${format(breaks[breaks.length - 1])} or more`,
+        color: colors[breaks.length],
+      });
+      continue; // eslint-disable-line
+    }
+
+    if (i === 0) {
+      breaksArray.push({
+        label: isPercent ? `Less than ${format(breaks[0])}` : `Under ${format(breaks[0])}`,
+        color: colors[0],
+      });
+      continue; // eslint-disable-line
+    }
+
+    breaksArray.push({
+      label: `${format(breaks[i - 1])} to ${format(breaks[i])}`,
+      color: colors[i],
+    });
+  }
+
+  return breaksArray;
+}
+
 export default Component.extend({
   handleGeographyLevelToggle() {},
   currentLayerConfig: {},
@@ -13,46 +55,22 @@ export default Component.extend({
     return title;
   },
 
+  @computed('currentLayerConfig')
+  icon({ type }) {
+    return type === 'circle' ? 'circle' : 'square';
+  },
+
   @computed('currentLayerConfig', 'isPercent', 'isChangeMeasurement')
-  breaks(layerConfig, isPercent, isChangeMeasurement) {
-    // return an array of objects, each with a display-ready range and color
-    const { paintConfig: config = {} } = layerConfig || {};
-    const { breaks = [], colors = [] } = config;
-
-    const format = (value) => { // eslint-disable-line
-
-      let formatter = '0.0a';
-      if (isPercent) formatter = '0.0%';
-      if (isChangeMeasurement) formatter = '+0.0';
-      if (isPercent && isChangeMeasurement) formatter = '+0.0%';
-
-      return numeral(value).format(formatter);
-    };
-
-    const breaksArray = [];
-
-    for (let i = breaks.length; i >= 0; i -= 1) {
-      if (i === breaks.length) {
-        breaksArray.push({
-          label: `${format(breaks[breaks.length - 1])} or more`,
-          color: colors[breaks.length],
-        });
-        continue; // eslint-disable-line
-      }
-
-      if (i === 0) {
-        breaksArray.push({
-          label: isPercent ? `Less than ${format(breaks[0])}` : `Under ${format(breaks[0])}`,
-          color: colors[0],
-        });
-        continue; // eslint-disable-line
-      }
-
-      breaksArray.push({
-        label: `${format(breaks[i - 1])} to ${format(breaks[i])}`,
-        color: colors[i],
-      });
+  rows(layerConfig, isPercent, isChangeMeasurement) {
+    const { type } = layerConfig;
+    if (type === 'choropleth') {
+      return getChoroplethRows(layerConfig, isPercent, isChangeMeasurement);
     }
-    return breaksArray;
+
+    if (type === 'circle') {
+      return layerConfig.legend;
+    }
+
+    return [];
   },
 });

--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -23,6 +23,7 @@ export default Component.extend({
 
       let formatter = '0.0a';
       if (isPercent) formatter = '0.0%';
+      if (isChangeMeasurement) formatter = '+0.0';
       if (isPercent && isChangeMeasurement) formatter = '+0.0%';
 
       return numeral(value).format(formatter);

--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -13,14 +13,19 @@ export default Component.extend({
     return title;
   },
 
-  @computed('currentLayerConfig', 'isPercent')
-  breaks(layerConfig, isPercent) {
+  @computed('currentLayerConfig', 'isPercent', 'isChangeMeasurement')
+  breaks(layerConfig, isPercent, isChangeMeasurement) {
     // return an array of objects, each with a display-ready range and color
     const { paintConfig: config = {} } = layerConfig || {};
     const { breaks = [], colors = [] } = config;
 
     const format = (value) => { // eslint-disable-line
-      return isPercent ? numeral(value).format('0,0%') : numeral(value).format('0,0');
+
+      let formatter = '0.0a';
+      if (isPercent) formatter = '0.0%';
+      if (isPercent && isChangeMeasurement) formatter = '+0.0%';
+
+      return numeral(value).format(formatter);
     };
 
     const breaksArray = [];
@@ -43,7 +48,7 @@ export default Component.extend({
       }
 
       breaksArray.push({
-        label: `${format(breaks[i - 1])} - ${format(breaks[i])}`,
+        label: `${format(breaks[i - 1])} to ${format(breaks[i])}`,
         color: colors[i],
       });
     }

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -122,23 +122,24 @@
   bottom: 40px;
   right: 10px;
   font-size: rem-calc(10);
-  background-color: rgba(255,255,255,0.8);
+  background-color: rgba(255,255,255,0.9);
   padding: rem-calc(6) rem-calc(10);
   border-radius: 4px;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
+  max-width: calc(50% - 10px);
 
-  @include breakpoint(large) {
+  @include breakpoint(medium) {
     bottom: 30px;
+    max-width: rem-calc(160);
   }
 
   .legend-title {
     font-size: rem-calc(11);
     margin-bottom: rem-calc(4);
-    max-width: 10em;
   }
 
   .legend-item {
-    border-top: 1px solid $light-gray;
+    border-top: 1px solid rgba(235,235,235,0.7);
     padding: 0;
 
     .legend-color {

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -139,7 +139,7 @@
 
   .legend-item {
     border-top: 1px solid $light-gray;
-    padding: rem-calc(2) 0;
+    padding: 0;
 
     .legend-color {
       margin: 0 rem-calc(4) 0 0;

--- a/app/templates/components/legend-box.hbs
+++ b/app/templates/components/legend-box.hbs
@@ -1,10 +1,10 @@
 {{#unless (eq layerTitle '')}}
   <div class="legend">
     <h5 class="legend-title">{{layerTitle}}</h5>
-    {{#each breaks as |break|}}
+    {{#each rows as |row|}}
       <div class="legend-item">
-        <span class="legend-color" style="color:{{break.color}};">{{fa-icon 'square'}}</span>
-        {{break.label}}
+        <span class="legend-color" style="color:{{row.color}};">{{fa-icon icon}}</span>
+        {{row.label}}
       </div>
     {{/each}}
   </div>

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -20,7 +20,8 @@
   {{!-- Legends --}}
   {{legend-box
     currentLayerConfig=currentLayerConfig
-    isPercent=mapConfig.map.isPercent
+    isPercent=mapConfig.isPercent
+    isChangeMeasurement=mapConfig.isChangeMeasurement
   }}
 
   {{!-- Geometry toggle --}}

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -81,6 +81,11 @@ map:
   - id: multifamily-permitted-municipality
     title: "Single vs. Multifamily Housing Units Permitted, 2010-2016"
     type: circle
+    legend:
+    - color: "#fc8d59"
+      label: "50 Single-family Units"
+    - color: "#91bfdb"
+      label: "50 Multi-family Units"
     source: multifamily-permitted
     source-layer: multifamily-permitted-municipality
     paint:

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -39,6 +39,11 @@ map:
     type: circle
     source: renter-owner
     source-layer: renter-owner-municipality
+    legend:
+    - color: "#fc8d59"
+      label: "50 Owner-occupied Units"
+    - color: "#91bfdb"
+      label: "50 Renter-occupied Units"
     paint:
       circle-color:
       - match

--- a/cms/maps/jobs-private-employment-change.yaml
+++ b/cms/maps/jobs-private-employment-change.yaml
@@ -35,6 +35,7 @@ map:
     value: empr0816
 
   isPercent: false
+  isChangeMeasurement: true
 
   layers:
   - id: private-employment-change-subregion

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -85,6 +85,11 @@ map:
   - id: net-population-change-municipality
     title: "Net Population Change, 2010 - 2016"
     type: circle
+    legend:
+    - color: "#ff7900"
+      label: "50 people lost"
+    - color: "#00aacc"
+      label: "50 people gained"
     source: net-population-change
     source-layer: net-population-change-municipality
     paint:

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -87,9 +87,9 @@ map:
     type: circle
     legend:
     - color: "#ff7900"
-      label: "50 people lost"
+      label: "Loss of 50 people"
     - color: "#00aacc"
-      label: "50 people gained"
+      label: "Gain of 50 people"
     source: net-population-change
     source-layer: net-population-change-municipality
     paint:

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -41,6 +41,7 @@ map:
     value: popa1016
 
   isPercent: false
+  isChangeMeasurement: true
 
   layers:
   - id: net-population-change-subregion

--- a/cms/maps/people-population-change.yaml
+++ b/cms/maps/people-population-change.yaml
@@ -34,6 +34,7 @@ map:
     value: popp1016
 
   isPercent: true
+  isChangeMeasurement: true
 
   layers:
   - id: population-change-subregion

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -84,9 +84,9 @@ map:
     type: circle
     legend:
     - color: "#ff7900"
-      label: "50 people lost"
+      label: "Loss of 50 people"
     - color: "#00aacc"
-      label: "50 people gained"
+      label: "Gain of 50 people"
     source: prime-labor-force-gain
     source-layer: prime-labor-force-gain-municipality
     paint:

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -82,6 +82,11 @@ map:
   - id: prime-labor-force-gain-municipality
     title: "Prime Labor Force Change, 2000-2016"
     type: circle
+    legend:
+    - color: "#ff7900"
+      label: "50 people lost"
+    - color: "#00aacc"
+      label: "50 people gained"
     source: prime-labor-force-gain
     source-layer: prime-labor-force-gain-municipality
     paint:

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -38,6 +38,7 @@ map:
     value: lfpw0016
 
   isPercent: false
+  isChangeMeasurement: true
 
   layers:
   - id: prime-labor-force-gain-subregion


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds different legends for dot density maps.  

- `legend-box` will render the legend differently depending on the `type` property in the config.  
- map configs for dot density maps now have a `legend` property, an array of objects with `color` and `label` properties that are rendered by `legend-box`

Closes #70
