### PR TITLE
76 percent legend zeroes

### DIFF
--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -23,6 +23,7 @@ export default Component.extend({
 
       let formatter = '0.0a';
       if (isPercent) formatter = '0.0%';
+      if (isChangeMeasurement) formatter = '+0.0';
       if (isPercent && isChangeMeasurement) formatter = '+0.0%';
 
       return numeral(value).format(formatter);

--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -13,14 +13,19 @@ export default Component.extend({
     return title;
   },
 
-  @computed('currentLayerConfig', 'isPercent')
-  breaks(layerConfig, isPercent) {
+  @computed('currentLayerConfig', 'isPercent', 'isChangeMeasurement')
+  breaks(layerConfig, isPercent, isChangeMeasurement) {
     // return an array of objects, each with a display-ready range and color
     const { paintConfig: config = {} } = layerConfig || {};
     const { breaks = [], colors = [] } = config;
 
     const format = (value) => { // eslint-disable-line
-      return isPercent ? numeral(value).format('0,0%') : numeral(value).format('0,0');
+
+      let formatter = '0.0a';
+      if (isPercent) formatter = '0.0%';
+      if (isPercent && isChangeMeasurement) formatter = '+0.0%';
+
+      return numeral(value).format(formatter);
     };
 
     const breaksArray = [];
@@ -43,7 +48,7 @@ export default Component.extend({
       }
 
       breaksArray.push({
-        label: `${format(breaks[i - 1])} - ${format(breaks[i])}`,
+        label: `${format(breaks[i - 1])} to ${format(breaks[i])}`,
         color: colors[i],
       });
     }

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -139,7 +139,7 @@
 
   .legend-item {
     border-top: 1px solid $light-gray;
-    padding: rem-calc(2) 0;
+    padding: 0;
 
     .legend-color {
       margin: 0 rem-calc(4) 0 0;

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -20,7 +20,8 @@
   {{!-- Legends --}}
   {{legend-box
     currentLayerConfig=currentLayerConfig
-    isPercent=mapConfig.map.isPercent
+    isPercent=mapConfig.isPercent
+    isChangeMeasurement=mapConfig.isChangeMeasurement
   }}
 
   {{!-- Geometry toggle --}}

--- a/cms/maps/jobs-private-employment-change.yaml
+++ b/cms/maps/jobs-private-employment-change.yaml
@@ -35,6 +35,7 @@ map:
     value: empr0816
 
   isPercent: false
+  isChangeMeasurement: true
 
   layers:
   - id: private-employment-change-subregion

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -41,6 +41,7 @@ map:
     value: popa1016
 
   isPercent: false
+  isChangeMeasurement: true
 
   layers:
   - id: net-population-change-subregion

--- a/cms/maps/people-population-change.yaml
+++ b/cms/maps/people-population-change.yaml
@@ -34,6 +34,7 @@ map:
     value: popp1016
 
   isPercent: true
+  isChangeMeasurement: true
 
   layers:
   - id: population-change-subregion

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -38,6 +38,7 @@ map:
     value: lfpw0016
 
   isPercent: false
+  isChangeMeasurement: true
 
   layers:
   - id: prime-labor-force-gain-subregion


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR:

-  adds `isChangeMeasurement` property to configs, which adds + and - to choropleth labels (Closes #92)
- fixes bug where percent-based choropleth legends were showing all zeroes (Closes #76)


