### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/app/templates/components/supporting-layers.hbs
+++ b/app/templates/components/supporting-layers.hbs
@@ -1,7 +1,7 @@
 {{#if (and railVisible railSource)}}
   {{#map.source sourceId='rail' options=railSource}}
-    {{map.layer layer=railConfig.lines before='waterway-label'}}
-    {{map.layer layer=railConfig.stops before='waterway-label'}}
+    {{map.layer layer=railConfig.lines before='poi-scalerank3'}}
+    {{map.layer layer=railConfig.stops before='poi-scalerank3'}}
   {{/map.source}}
 {{/if}}
 

--- a/app/utils/get-popup-sql.js
+++ b/app/utils/get-popup-sql.js
@@ -11,7 +11,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
   const SQLArray = [];
 
   SQLArray.push(`
-    SELECT 'region' as geomtype, 'NYC region' as name, 100000 as value
+    SELECT 'region' as geomtype, 'NYC region' as name, ${getPopupValue('region')} as value FROM region_region_v0
   `);
 
   if (getPopupValue('subregion')) {

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -4,7 +4,7 @@ slug: multifamily-permitted
 category: Housing
 categorySlug: housing
 title: "NYC accounted for XX% of multifamily housing units permitted in the region since 2010."
-menuTitle: "Multifamily Housing Units Permitted, 2010-2016"
+menuTitle: "Housing Units Permitted by Building Type"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, random_value FROM region_unittype_dotdensity_v2
 
   popupValues:
+  - id: region
+    value: houps1016
   - id: subregion
     value: houps1016
   - id: county

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -4,7 +4,7 @@ slug: multifamily-permitted
 category: Housing
 categorySlug: housing
 title: "NYC accounted for XX% of multifamily housing units permitted in the region since 2010."
-menuTitle: "Housing Units Permitted by Building Type"
+menuTitle: "Housing Units Permitted by Building Size"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -4,7 +4,7 @@ slug: renter-owner
 category: Housing
 categorySlug: housing
 title: "The region is roughly split between owner- (XX%) and renter-occupied (XX%) housing units"
-menuTitle: "Housing Units by Renter vs. Owner, 2012-2016 Avg"
+menuTitle: "Housing Units, Owner- vs. Renter-Occupied"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -24,6 +24,8 @@ map:
       sql: SELECT the_geom_webmercator, random_value FROM region_tenure_dotdensity_v0
 
   popupValues:
+  - id: region
+    value: houa16
   - id: subregion
     value: houa16
   - id: county

--- a/cms/maps/housing-total-units.yaml
+++ b/cms/maps/housing-total-units.yaml
@@ -4,7 +4,7 @@ slug: total-units
 category: Housing
 categorySlug: housing
 title: "NYC has 38% of the region's 9 million housing units"
-menuTitle: "Total Housing Units, 2012-2016 Avg"
+menuTitle: "Total Housing Units"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/housing-total-units.yaml
+++ b/cms/maps/housing-total-units.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, hou16 as value FROM region_municipality_v0
 
   popupValues:
+  - id: region
+    value: houa16
   - id: subregion
     value: houa16
   - id: county

--- a/cms/maps/housing-units-permitted.yaml
+++ b/cms/maps/housing-units-permitted.yaml
@@ -4,7 +4,7 @@ slug: units-permitted
 category: Housing
 categorySlug: housing
 title: "NYC accounted for about 40% of housing units permitted since 2010"
-menuTitle: "Housing Units Permitted, 2010-2016"
+menuTitle: "Total Housing Units Permitted"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/housing-units-permitted.yaml
+++ b/cms/maps/housing-units-permitted.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, houp1016 as value FROM region_municipality_v0
 
   popupValues:
+  - id: region
+    value: houp1016
   - id: subregion
     value: houp1016
   - id: county

--- a/cms/maps/jobs-private-employment-change.yaml
+++ b/cms/maps/jobs-private-employment-change.yaml
@@ -29,6 +29,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, empr0816 as value FROM region_county_v0
 
   popupValues:
+  - id: region
+    value: empr0816
   - id: subregion
     value: empr0816
   - id: county

--- a/cms/maps/jobs-total-employment.yaml
+++ b/cms/maps/jobs-total-employment.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, emtot15 as value FROM region_municipality_v0
 
   popupValues:
+  - id: region
+    value: emtot16
   - id: subregion
     value: emtot16
   - id: county

--- a/cms/maps/people-foreign-born.yaml
+++ b/cms/maps/people-foreign-born.yaml
@@ -4,7 +4,7 @@ slug: foreign-born
 category: People
 categorySlug: people
 title: "Foreign-born residents are a significant share of the population in growing parts of the region."
-menuTitle: "Foreign Born as Share of Total Population, 2012-2016 Avg"
+menuTitle: "% Foreign Born"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/people-foreign-born.yaml
+++ b/cms/maps/people-foreign-born.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, popfbp16 as value FROM region_municipality_v0
 
   popupValues:
+  - id: region
+    value: popfbp16
   - id: subregion
     value: popfbp16
   - id: county

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -4,7 +4,7 @@ slug: net-population-change
 category: People
 categorySlug: people
 title: "Most noticeable gains outside of NYC are in select municipalities along regional rail corridors and in North NJ"
-menuTitle: "Net Population Change, 2010 - 2016"
+menuTitle: "Net Population Change"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -33,6 +33,8 @@ map:
       sql: SELECT the_geom_webmercator, popa1016, popa1016si as value FROM region_popa1016_dotdensity_v0
 
   popupValues:
+  - id: region
+    value: pop1016
   - id: subregion
     value: pop1016
   - id: county

--- a/cms/maps/people-population-change.yaml
+++ b/cms/maps/people-population-change.yaml
@@ -28,6 +28,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, popp1016 as value FROM region_county_v0
 
   popupValues:
+  - id: region
+    value: popp1016
   - id: subregion
     value: popp1016
   - id: county

--- a/cms/maps/people-population-change.yaml
+++ b/cms/maps/people-population-change.yaml
@@ -4,7 +4,7 @@ slug: population-change
 category: People
 categorySlug: people
 title: "Since 2010, population gains have recentralized, with outer counties losing population"
-menuTitle: "% Population Change, 2010-2016"
+menuTitle: "% Population Change"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/people-population-density.yaml
+++ b/cms/maps/people-population-density.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, popaden16 as value FROM region_municipality_v0
 
   popupValues:
+  - id: region
+    value: popepd16
   - id: subregion
     value: popepd16
   - id: county

--- a/cms/maps/people-population-density.yaml
+++ b/cms/maps/people-population-density.yaml
@@ -4,7 +4,7 @@ slug: population-density
 category: People
 categorySlug: people
 title: "The region is densest at the core"
-menuTitle: "Population Density (Pop/sq. mile) 2016"
+menuTitle: "Population Density"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -4,7 +4,7 @@ slug: prime-labor-force-gain
 category: People
 categorySlug: people
 title: "NYC gain of prime labor force (participants age 25 to 54) outpaced the regional net gain from 2000-2016."
-menuTitle: "Prime Labor Force Change, 2000-2016"
+menuTitle: "Prime Labor Force Change"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, lfpw0016, lfpw0016si as value FROM region_lfpw0016_dotdensity_v0
 
   popupValues:
+  - id: region
+    value: lfpw0016
   - id: subregion
     value: lfpw0016
   - id: county

--- a/cms/maps/people-total-population.yaml
+++ b/cms/maps/people-total-population.yaml
@@ -4,7 +4,7 @@ slug: total-population
 category: People
 categorySlug: people
 title: "NYC represents 37% of the region's population of 22.8 Million"
-menuTitle: "Total Population 2016"
+menuTitle: "Total Population"
 content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 source: This maps show data from some source.

--- a/cms/maps/people-total-population.yaml
+++ b/cms/maps/people-total-population.yaml
@@ -32,6 +32,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, popa16 as value FROM region_municipality_v0
 
   popupValues:
+  - id: region
+    value: popep16
   - id: subregion
     value: popep16
   - id: county

--- a/cms/meta.yaml
+++ b/cms/meta.yaml
@@ -25,9 +25,9 @@ orderings:
     # Housing
     - id: total-units
       hasNarrative: true
-    - id: units-permitted
-      hasNarrative: true
     - id: renter-owner
+      hasNarrative: true
+    - id: units-permitted
       hasNarrative: true
     - id: multifamily-permitted
       hasNarrative: true

--- a/cms/meta.yaml
+++ b/cms/meta.yaml
@@ -9,17 +9,17 @@ orderings:
       hideFromMenu: true
 
     # People
-    - id: foreign-born
-      hasNarrative: true
-    - id: net-population-change
-      hasNarrative: true
-    - id: population-change
+    - id: total-population
       hasNarrative: true
     - id: population-density
       hasNarrative: true
-    - id: prime-labor-force-gain
+    - id: population-change
       hasNarrative: true
-    - id: total-population
+    - id: net-population-change
+      hasNarrative: true
+    - id: foreign-born
+      hasNarrative: true
+    - id: prime-labor-force-gain
       hasNarrative: true
 
     # Housing


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR
- Adds the appropriate query to the popup util, adding NYC region totals (also updates all configs to include `region` in `popupValues` ( Closes #86 )
- Re-order and update `menuTitle` for all housing maps (Closes #98)
- Re-order and update `menuTitle` for all people maps (Closes #88)
- Change `before` parameter of the regional rail layers so they always appear above the choropleth/dot density layers (Closes #103)
