### PR TITLE
Popup configs (+ Long Island fix)

### DIFF
--- a/app/components/map-from-id.js
+++ b/app/components/map-from-id.js
@@ -155,7 +155,7 @@ export default Component.extend({
       const layers = this.get('visibleLayers').map(d => d.id);
       const feature = e.target.queryRenderedFeatures(e.point, { layers })[0];
       const popup = this.get('popup');
-      const { isPercent, popupColumns } = this.get('mapConfig');
+      const { popupColumns, isPermitMap, isPercent } = this.get('mapConfig');
 
       // Add the popup with a spinner before loading its data
       popup.setLngLat(e.lngLat)
@@ -169,7 +169,7 @@ export default Component.extend({
 
         carto.SQL(SQL)
           .then((data) => {
-            popup.setHTML(buildPopupContent(data, geographyLevel, popupColumns, isPercent));
+            popup.setHTML(buildPopupContent(data, geographyLevel, popupColumns, isPermitMap, isPercent));
           });
       } else {
         popup.remove();

--- a/app/utils/build-popup-content.js
+++ b/app/utils/build-popup-content.js
@@ -1,6 +1,6 @@
 import numeral from 'numeral';
 
-export default function buildPopupContent(data, geographyLevel, popupColumns, isPermitMap=false, isPercent) {
+export default function buildPopupContent(data, geographyLevel, popupColumns, isPermitMap, isPercent) {
   // create rows for the table body
   let rowStrings = data.map((rowData) => {
     const isHighlighted = geographyLevel === rowData.geomtype ? 'highlighted' : '';

--- a/app/utils/build-popup-content.js
+++ b/app/utils/build-popup-content.js
@@ -35,6 +35,10 @@ export default function buildPopupContent(data, geographyLevel, popupColumns, is
       `);
     }).join('');
 
+    if (rowData.houptest === 'Y') {
+      return '';
+    }
+
     return (`
       <tr class="${isHighlighted}">
         <td class="geom">

--- a/app/utils/build-popup-content.js
+++ b/app/utils/build-popup-content.js
@@ -1,6 +1,6 @@
 import numeral from 'numeral';
 
-export default function buildPopupContent(data, geographyLevel, popupColumns, isPercent) {
+export default function buildPopupContent(data, geographyLevel, popupColumns, isPermitMap=false, isPercent) {
   // create rows for the table body
   let rowStrings = data.map((rowData) => {
     const isHighlighted = geographyLevel === rowData.geomtype ? 'highlighted' : '';
@@ -35,7 +35,14 @@ export default function buildPopupContent(data, geographyLevel, popupColumns, is
       `);
     }).join('');
 
-    if (rowData.houptest === 'Y') {
+    // If this is a Permit Map
+    if (isPermitMap) {
+      // hide the rows that are Long Island municipalities that do not report housing permit data
+      if (rowData.houptest === 'N') {
+        return '';
+      }
+    } else if (rowData.islitown === 'Y') {
+      // If it's not a Permit Map, always hide the Long Island town rows
       return '';
     }
 

--- a/app/utils/get-popup-sql.js
+++ b/app/utils/get-popup-sql.js
@@ -17,13 +17,13 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
   const SQLArray = [];
 
   SQLArray.push(`
-    SELECT 'region' as geomtype, null as houptest, 'Total Metro Area' as name ${getPopupValue('region')}
+    SELECT 'region' as geomtype, null as islitown, null as houptest, 'Total Metro Area' as name ${getPopupValue('region')}
     FROM region_region_v0
   `);
 
   if (getPopupValue('subregion')) {
     SQLArray.push(`
-      SELECT 'subregion' as geomtype, null as houptest, name as name ${getPopupValue('subregion')}
+      SELECT 'subregion' as geomtype, null as islitown, null as houptest, name as name ${getPopupValue('subregion')}
       FROM region_subregion_v0
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);
@@ -33,7 +33,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
 
   if (getPopupValue('county')) {
     SQLArray.push(`
-      SELECT 'county' as geomtype, null as houptest, name as name ${getPopupValue('county')}
+      SELECT 'county' as geomtype, null as islitown, null as houptest, name as name ${getPopupValue('county')}
       FROM region_county_v0
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);
@@ -43,7 +43,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
 
   if (getPopupValue('municipality')) {
     SQLArray.push(`
-      SELECT 'municipality' as geomtype, houptest, namelsad as name ${getPopupValue('municipality')}
+      SELECT 'municipality' as geomtype, islitown, houptest, namelsad as name ${getPopupValue('municipality')}
       FROM region_municipality_v0
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);

--- a/app/utils/get-popup-sql.js
+++ b/app/utils/get-popup-sql.js
@@ -17,13 +17,13 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
   const SQLArray = [];
 
   SQLArray.push(`
-    SELECT 'region' as geomtype, 'Total Metro Area' as name ${getPopupValue('region')}
+    SELECT 'region' as geomtype, null as houptest, 'Total Metro Area' as name ${getPopupValue('region')}
     FROM region_region_v0
   `);
 
   if (getPopupValue('subregion')) {
     SQLArray.push(`
-      SELECT 'subregion' as geomtype, name as name ${getPopupValue('subregion')}
+      SELECT 'subregion' as geomtype, null as houptest, name as name ${getPopupValue('subregion')}
       FROM region_subregion_v0
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);
@@ -33,7 +33,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
 
   if (getPopupValue('county')) {
     SQLArray.push(`
-      SELECT 'county' as geomtype, name as name ${getPopupValue('county')}
+      SELECT 'county' as geomtype, null as houptest, name as name ${getPopupValue('county')}
       FROM region_county_v0
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);
@@ -43,7 +43,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
 
   if (getPopupValue('municipality')) {
     SQLArray.push(`
-      SELECT 'municipality' as geomtype, namelsad as name ${getPopupValue('municipality')}
+      SELECT 'municipality' as geomtype, houptest, namelsad as name ${getPopupValue('municipality')}
       FROM region_municipality_v0
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -53,6 +53,8 @@ map:
       cv:
       sig:
 
+  isPermitMap: true
+
   isPercent: false
 
   layers:

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -33,7 +33,7 @@ map:
 
   popupColumns:
   - id: houps
-    title: Units
+    title: Units Permitted
     large: true
     values:
     - geomType: region

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -24,25 +24,83 @@ map:
       sql: SELECT the_geom_webmercator, random_value FROM region_tenure_dotdensity_v0
 
   popupColumns:
-  - id: hou
+  - id: owner
     title: Units
     large: true
     values:
     - geomType: region
-      columnName: houa16
+      columnName: houo16
       cv:
       sig:
     - geomType: subregion
-      columnName: houa16
-      cv:
+      columnName: houo16
+      cv: houo16cv
       sig:
     - geomType: county
-      columnName: houa16
-      cv:
+      columnName: houo16
+      cv: houo16cv
       sig:
     - geomType: municipality
-      columnName: hou16
+      columnName: houo16
+      cv: houo16cv
+      sig:
+  - id: ownermoe
+    title: MOE
+    values:
+    - geomType: region
+      columnName:
       cv:
+      sig:
+    - geomType: subregion
+      columnName: houo16moe
+      cv: houo16cv
+      sig:
+    - geomType: county
+      columnName: houo16moe
+      cv: houo16cv
+      sig:
+    - geomType: municipality
+      columnName: houo16moe
+      cv: houo16cv
+      sig:
+  - id: renter
+    title: Units
+    large: true
+    values:
+    - geomType: region
+      columnName: hour16
+      cv:
+      sig:
+    - geomType: subregion
+      columnName: hour16
+      cv: hour16cv
+      sig:
+    - geomType: county
+      columnName: hour16
+      cv: hour16cv
+      sig:
+    - geomType: municipality
+      columnName: hour16
+      cv: hour16cv
+      sig:
+  - id: rentermoe
+    title: MOE
+    values:
+    - geomType: region
+      columnName:
+      cv:
+      sig:
+    - geomType: subregion
+      columnName: hour16moe
+      cv: hour16cv
+      sig:
+    - geomType: county
+      columnName: hour16moe
+      cv: hour16cv
+      sig:
+    - geomType: municipality
+      columnName: hour16moe
+      cv: hour16cv
       sig:
 
   isPercent: false

--- a/cms/maps/housing-total-units.yaml
+++ b/cms/maps/housing-total-units.yaml
@@ -32,7 +32,7 @@ map:
       sql: SELECT the_geom_webmercator, geoid, hou16 as value FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
-  - id: hou
+  - id: totalunits
     title: Units
     large: true
     values:
@@ -42,15 +42,34 @@ map:
       sig:
     - geomType: subregion
       columnName: houa16
-      cv:
+      cv: houa16cv
       sig:
     - geomType: county
       columnName: houa16
-      cv:
+      cv: houa16cv
       sig:
     - geomType: municipality
       columnName: hou16
+      cv: hou16cv
+      sig:
+  - id: moe
+    title: MOE
+    values:
+    - geomType: region
+      columnName:
       cv:
+      sig:
+    - geomType: subregion
+      columnName: houa16moe
+      cv: houa16cv
+      sig:
+    - geomType: county
+      columnName: houa16moe
+      cv: houa16cv
+      sig:
+    - geomType: municipality
+      columnName: hou16moe
+      cv: hou16cv
       sig:
 
   isPercent: false

--- a/cms/maps/housing-units-permitted.yaml
+++ b/cms/maps/housing-units-permitted.yaml
@@ -33,7 +33,7 @@ map:
 
   popupColumns:
   - id: houp
-    title: Units
+    title: Units Permitted
     large: true
     values:
     - geomType: region

--- a/cms/maps/housing-units-permitted.yaml
+++ b/cms/maps/housing-units-permitted.yaml
@@ -53,6 +53,8 @@ map:
       cv:
       sig:
 
+  isPermitMap: true
+
   isPercent: false
 
   layers:

--- a/cms/maps/people-foreign-born.yaml
+++ b/cms/maps/people-foreign-born.yaml
@@ -42,15 +42,34 @@ map:
       sig:
     - geomType: subregion
       columnName: popfbp16
-      cv:
+      cv: popfbp16cv
       sig:
     - geomType: county
       columnName: popfbp16
-      cv:
+      cv: popfbp16cv
       sig:
     - geomType: municipality
       columnName: popfbp16
+      cv: popfbp16cv
+      sig:
+  - id: moe
+    title: MOE
+    values:
+    - geomType: region
+      columnName:
       cv:
+      sig:
+    - geomType: subregion
+      columnName: popfbp16mo
+      cv: popfbp16cv
+      sig:
+    - geomType: county
+      columnName: popfbp16mo
+      cv: popfbp16cv
+      sig:
+    - geomType: municipality
+      columnName: popfbp16mo
+      cv: popfbp16cv
       sig:
 
   isPercent: true

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -53,6 +53,25 @@ map:
       columnName: popa1016
       cv:
       sig:
+  - id: moe
+    title: MOE
+    values:
+    - geomType: region
+      columnName:
+      cv:
+      sig:
+    - geomType: subregion
+      columnName:
+      cv:
+      sig:
+    - geomType: county
+      columnName:
+      cv:
+      sig:
+    - geomType: municipality
+      columnName: popa1016mo
+      cv:
+      sig: popa1016si
 
   isPercent: false
   isChangeMeasurement: true

--- a/cms/maps/people-population-density.yaml
+++ b/cms/maps/people-population-density.yaml
@@ -50,7 +50,26 @@ map:
       sig:
     - geomType: municipality
       columnName: popaden16
+      cv: popacv16
+      sig:
+  - id: moe
+    title: MOE
+    values:
+    - geomType: region
+      columnName:
       cv:
+      sig:
+    - geomType: subregion
+      columnName:
+      cv:
+      sig:
+    - geomType: county
+      columnName:
+      cv:
+      sig:
+    - geomType: municipality
+      columnName: popacv16
+      cv: popacv16
       sig:
 
   isPercent: false

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -48,6 +48,25 @@ map:
       columnName: lfpw0016
       cv:
       sig: lfpw0016si
+  - id: moe
+    title: MOE
+    values:
+    - geomType: region
+      columnName:
+      cv:
+      sig:
+    - geomType: subregion
+      columnName: lfpw0016mo
+      cv:
+      sig: lfpw0016si
+    - geomType: county
+      columnName: lfpw0016mo
+      cv:
+      sig: lfpw0016si
+    - geomType: municipality
+      columnName: lfpw0016mo
+      cv:
+      sig: lfpw0016si
 
   isPercent: false
   isChangeMeasurement: true

--- a/tests/unit/utils/build-popup-content-test.js
+++ b/tests/unit/utils/build-popup-content-test.js
@@ -9,7 +9,7 @@ const popupColumns = [{"id":"pop","title":"Population","large":true,"values":[{"
 
 // Replace this with your real tests.
 test('it renders a table tag', function(assert) {
-  let result = buildPopupContent(data, 'county', popupColumns, false);
+  let result = buildPopupContent(data, 'county', popupColumns, false, false);
 
   const foundTable = result.indexOf('<table class="popup-table">') > -1
   assert.ok(result);


### PR DESCRIPTION
This PR… 
- Updates all the map configs to include MOEs, CVs, SIGs. 
- Conditionally hides rows in the popup — Long Island swiss cheese — using `houptest` and `islitown` when `isPermitMap` is true. Closes #84. 