### PR TITLE
89 show muni boundaries

### DIFF
--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -46,30 +46,26 @@ function getChoroplethRows(layerConfig, isPercent, isChangeMeasurement) {
 
 export default Component.extend({
   handleGeographyLevelToggle() {},
-  currentLayerConfig: {},
+  currentLayerGroup: {},
   mapConfig: {},
 
-  @computed('currentLayerConfig')
+  @computed('currentLayerGroup')
   layerTitle({ title = '' } = {}) {
     return title;
   },
 
-  @computed('currentLayerConfig')
+  @computed('currentLayerGroup')
   icon({ type }) {
     return type === 'circle' ? 'circle' : 'square';
   },
 
-  @computed('currentLayerConfig', 'isPercent', 'isChangeMeasurement')
+  @computed('currentLayerGroup', 'isPercent', 'isChangeMeasurement')
   rows(layerConfig, isPercent, isChangeMeasurement) {
-    const { type } = layerConfig;
-    if (type === 'choropleth') {
-      return getChoroplethRows(layerConfig, isPercent, isChangeMeasurement);
+    const { legend } = layerConfig;
+    if (typeof legend === 'string') {
+      return getChoroplethRows(layerConfig.layers.find(layer => layer.id === legend), isPercent, isChangeMeasurement);
     }
 
-    if (type === 'circle') {
-      return layerConfig.legend;
-    }
-
-    return [];
+    return layerConfig.legend;
   },
 });

--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -50,11 +50,6 @@ export default Component.extend({
   mapConfig: {},
 
   @computed('currentLayerGroup')
-  layerTitle({ title = '' } = {}) {
-    return title;
-  },
-
-  @computed('currentLayerGroup')
   icon({ type }) {
     return type === 'circle' ? 'circle' : 'square';
   },

--- a/app/components/map-from-id.js
+++ b/app/components/map-from-id.js
@@ -36,15 +36,14 @@ export default Component.extend({
   },
 
   @computed('mapConfig', 'geographyLevel')
-  currentLayerConfig(mapConfig, geographyLevel) {
-    const { toggles = [] } = mapConfig;
-    const foundLayer = toggles.find(d => d.type === geographyLevel) || {};
-    const { layerId: currentLayerId } = foundLayer;
+  currentLayerGroup(mapConfig, geographyLevel) {
+    const { layerGroups = [] } = mapConfig;
+    const foundLayerGroup = layerGroups.find(d => d.id === geographyLevel) || {};
 
-    return mapConfig.layers.find(d => d.id === currentLayerId);
+    return foundLayerGroup;
   },
 
-  @computed('currentLayerConfig')
+  @computed('currentLayerGroup')
   mapTitle(layerConfig) {
     return layerConfig ? layerConfig.title : '';
   },
@@ -79,16 +78,10 @@ export default Component.extend({
   },
 
   @computed('mapConfig', 'geographyLevel')
-  visibleLayers({ mapboxLayers: layers = [], toggles = [] }, selectedGeographyLevel) {
-    // find toggle-able layers to hide
-    // 1. find which toggle-ables are not selected
-    // 2. grab those from the layers
-    const hiddenLayersIDs = toggles
-      .filter(toggle => toggle.type !== selectedGeographyLevel)
-      .mapBy('layerId');
-
-    return layers
-      .filter(layer => !hiddenLayersIDs.some(layerId => (layer.id === layerId || layer.id === `${layerId}-line`)));
+  visibleLayers({ mapboxLayers = [] }, selectedGeographyLevel) {
+    return mapboxLayers
+      .find(layerGroup => layerGroup.id === selectedGeographyLevel)
+      .layers;
   },
 
   didReceiveAttrs() {
@@ -182,9 +175,7 @@ export default Component.extend({
     },
 
     handleGeographyLevelToggle(geog) {
-      const popup = this.get('popup');
-
-      popup.remove();
+      this.get('popup').remove();
       this.set('toggledGeographyLevel', geog);
     },
   },

--- a/app/components/map-from-id.js
+++ b/app/components/map-from-id.js
@@ -146,7 +146,9 @@ export default Component.extend({
         this.set('highlightedFeature', null);
       }
 
-      map.getCanvas().style.cursor = feature ? 'pointer' : '';
+      const { popupColumns } = this.get('mapConfig');
+
+      map.getCanvas().style.cursor = (feature && popupColumns) ? 'pointer' : '';
     },
 
     handleMouseClick(e) {

--- a/app/routes/map.js
+++ b/app/routes/map.js
@@ -40,38 +40,43 @@ export default Route.extend({
         return mapNarrative;
       })
       .then((enrichedMapNarrative) => {
-        const { map: { layers } } = enrichedMapNarrative;
-        const builtLayers = [];
+        const { map: { layerGroups } } = enrichedMapNarrative;
+        const builtLayerGroups = layerGroups.map(layerGroup => ({
+          id: layerGroup.id,
+          layers: [],
+        }));
 
-        layers.forEach((layer) => {
-          if (layer.type === 'choropleth') {
-            const { id, source, paintConfig } = layer;
-            builtLayers.push({
-              id,
-              type: 'fill',
-              source,
-              'source-layer': layer['source-layer'],
-              paint: buildPaint(paintConfig),
-            });
+        layerGroups.forEach(({ layers }, i) => {
+          layers.forEach((layer) => {
+            if (layer.type === 'choropleth') {
+              const { id, source, paintConfig } = layer;
+              builtLayerGroups[i].layers.push({
+                id,
+                type: 'fill',
+                source,
+                'source-layer': layer['source-layer'],
+                paint: buildPaint(paintConfig),
+              });
 
-            // for choropleth fill layers, push an outlines line layer as well
-            builtLayers.push({
-              id: `${id}-line`,
-              type: 'line',
-              source,
-              'source-layer': layer['source-layer'],
-              paint: {
-                'line-color': 'rgba(131, 131, 131, 1)',
-                'line-width': 0.5,
-              },
-            });
-          } else {
-            // no building necessary if not type choropleth
-            builtLayers.push(layer);
-          }
+              // for choropleth fill layers, push an outlines line layer as well
+              builtLayerGroups[i].layers.push({
+                id: `${id}-line`,
+                type: 'line',
+                source,
+                'source-layer': layer['source-layer'],
+                paint: {
+                  'line-color': 'rgba(131, 131, 131, 1)',
+                  'line-width': 0.5,
+                },
+              });
+            } else {
+              // no building necessary if not type choropleth
+              builtLayerGroups[i].layers.push(layer);
+            }
+          });
         });
 
-        set(enrichedMapNarrative, 'map.mapboxLayers', builtLayers);
+        set(enrichedMapNarrative, 'map.mapboxLayers', builtLayerGroups);
         // set(enrichedMapNarrative, 'map.legends', layers);
         return enrichedMapNarrative;
       });

--- a/app/templates/components/geometry-toggle.hbs
+++ b/app/templates/components/geometry-toggle.hbs
@@ -1,8 +1,8 @@
 <ul class="menu geography-selector">
-  {{#each toggles as |toggle|}}
-    <li class="{{if (eq geographyLevel toggle.type) 'active'}} explode-block toggle-list-item">
-      <a {{action handleGeographyLevelToggle toggle.type}}>
-        {{capitalize toggle.type}}
+  {{#each layerGroups as |layerGroup|}}
+    <li class="{{if (eq geographyLevel layerGroup.id) 'active'}} explode-block toggle-list-item">
+      <a {{action handleGeographyLevelToggle layerGroup.id}}>
+        {{capitalize layerGroup.id}}
       </a>
     </li>
   {{/each}}

--- a/app/templates/components/legend-box.hbs
+++ b/app/templates/components/legend-box.hbs
@@ -1,6 +1,5 @@
-{{#unless (eq layerTitle '')}}
   <div class="legend">
-    {{#if narrativeVisible}}<h5 class="legend-title">{{layerTitle}}</h5>{{/if}}
+    {{#if narrativeVisible}}<h5 class="legend-title">{{currentLayerGroup.title}}</h5>{{/if}}
     {{#each rows as |row|}}
       <div class="legend-item">
         <span class="legend-color" style="color:{{row.color}};">{{fa-icon icon}}</span>
@@ -8,4 +7,3 @@
       </div>
     {{/each}}
   </div>
-{{/unless}}

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -19,7 +19,7 @@
 
   {{!-- Legends --}}
   {{legend-box
-    currentLayerConfig=currentLayerConfig
+    currentLayerGroup=currentLayerGroup
     isPercent=mapConfig.isPercent
     isChangeMeasurement=mapConfig.isChangeMeasurement
     narrativeVisible=narrativeVisible
@@ -29,9 +29,8 @@
   {{geometry-toggle
     geographyLevel=geographyLevel
     handleGeographyLevelToggle=(action 'handleGeographyLevelToggle')
-    toggles=mapConfig.toggles
+    layerGroups=mapConfig.layerGroups
   }}
-
 
   {{yield (hash mapboxGl=map)}}
 

--- a/app/templates/components/map-from-id.hbs
+++ b/app/templates/components/map-from-id.hbs
@@ -18,12 +18,14 @@
   {{/if}}
 
   {{!-- Legends --}}
-  {{legend-box
-    currentLayerGroup=currentLayerGroup
-    isPercent=mapConfig.isPercent
-    isChangeMeasurement=mapConfig.isChangeMeasurement
-    narrativeVisible=narrativeVisible
-  }}
+  {{#if currentLayerGroup.legend}}
+    {{legend-box
+      currentLayerGroup=currentLayerGroup
+      isPercent=mapConfig.isPercent
+      isChangeMeasurement=mapConfig.isChangeMeasurement
+      narrativeVisible=narrativeVisible
+    }}
+  {{/if}}
 
   {{!-- Geometry toggle --}}
   {{geometry-toggle
@@ -35,7 +37,9 @@
   {{yield (hash mapboxGl=map)}}
 
   {{map.on 'mousemove' (action 'handleMouseMove')}}
-  {{map.on 'click' (action 'handleMouseClick')}}
+  {{#if mapConfig.popupColumns}}
+    {{map.on 'click' (action 'handleMouseClick')}}
+  {{/if}}
 {{/mapbox-gl}}
 
 {{#if highlightedFeature}}

--- a/cms/maps/balance-housjobs00.yaml
+++ b/cms/maps/balance-housjobs00.yaml
@@ -10,12 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: balance-housjobs00-subregion
-    type: subregion
-  - layerId: balance-housjobs00-county
-    type: county
-
   defaultGeographyLevel: county
 
   sources:
@@ -48,44 +42,52 @@ map:
   isPercent: false
   isChangeMeasurement: false
 
-  layers:
-  - id: balance-housjobs00-subregion
+  # Layergroups
+
+  layerGroups:
+  - id: subregion
     title: "Housing Units/Total Employment 2000"
-    type: choropleth
-    source: balance-housjobs00
-    source-layer: balance-housjobs00-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#127723"
-      - "#89dfa4"
-      - "#ffffe0"
-      - "#ffa555"
-      - "#d76523"
-      breaks:
-      - 0.825
-      - 0.85
-      - 0.9
-      - 0.95
-  - id: balance-housjobs00-county
+    legend: balance-housjobs00-subregion
+    layers:
+    - id: balance-housjobs00-subregion
+      type: choropleth
+      source: balance-housjobs00
+      source-layer: balance-housjobs00-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#127723"
+        - "#89dfa4"
+        - "#ffffe0"
+        - "#ffa555"
+        - "#d76523"
+        breaks:
+        - 0.825
+        - 0.85
+        - 0.9
+        - 0.95
+  - id: county
     title: "Housing Units/Total Employment 2000"
-    type: choropleth
-    source: balance-housjobs00
-    source-layer: balance-housjobs00-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#193f1f"
-      - "#127723"
-      - "#89dfa4"
-      - "#ffffe0"
-      - "#ffa555"
-      - "#d76523"
-      - "#87390c"
-      breaks:
-      - 0.4
-      - 0.6
-      - 0.85
-      - 0.9
-      - 1.15
-      - 1.75
+    legend: balance-housjobs00-county
+    layers:
+    - id: balance-housjobs00-county
+      type: choropleth
+      source: balance-housjobs00
+      source-layer: balance-housjobs00-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#193f1f"
+        - "#127723"
+        - "#89dfa4"
+        - "#ffffe0"
+        - "#ffa555"
+        - "#d76523"
+        - "#87390c"
+        breaks:
+        - 0.4
+        - 0.6
+        - 0.85
+        - 0.9
+        - 1.15
+        - 1.75

--- a/cms/maps/balance-housjobs00.yaml
+++ b/cms/maps/balance-housjobs00.yaml
@@ -17,9 +17,9 @@ map:
     type: cartovector
     source-layers:
     - id: balance-housjobs00-subregion
-      sql: SELECT the_geom_webmercator, geoid, balhj00 as value FROM region_subregion_v0
+      sql: SELECT the_geom_webmercator, geoid, balhj00 as value, name FROM region_subregion_v0
     - id: balance-housjobs00-county
-      sql: SELECT the_geom_webmercator, geoid, balhj00 as value FROM region_county_v0
+      sql: SELECT the_geom_webmercator, geoid, balhj00 as value, name FROM region_county_v0
 
   popupColumns:
   - id: balhj

--- a/cms/maps/balance-housjobs0016.yaml
+++ b/cms/maps/balance-housjobs0016.yaml
@@ -10,12 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: balance-housjobs0016-subregion
-    type: subregion
-  - layerId: balance-housjobs0016-county
-    type: county
-
   defaultGeographyLevel: county
 
   sources:
@@ -48,42 +42,48 @@ map:
   isPercent: false
   isChangeMeasurement: true
 
-  layers:
-  - id: balance-housjobs0016-subregion
+  layerGroups:
+  - id: subregion
     title: "Housing Units Produced vs. Change in Total Employment, 2000-2016"
-    type: choropleth
-    source: balance-housjobs0016
-    source-layer: balance-housjobs0016-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#127723"
-      - "#89dfa4"
-      - "#ffffe0"
-      - "#ffa555"
-      - "#d76523"
-      breaks:
-      - -50000
-      - -15000
-      - 15000
-      - 50000
-  - id: balance-housjobs0016-county
+    legend: balance-housjobs0016-subregion
+    layers:
+    - id: balance-housjobs0016-subregion
+      type: choropleth
+      source: balance-housjobs0016
+      source-layer: balance-housjobs0016-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#127723"
+        - "#89dfa4"
+        - "#ffffe0"
+        - "#ffa555"
+        - "#d76523"
+        breaks:
+        - -50000
+        - -15000
+        - 15000
+        - 50000
+  - id: county
     title: "Housing Units Produced vs. Change in Total Employment, 2000-2016"
-    type: choropleth
-    source: balance-housjobs0016
-    source-layer: balance-housjobs0016-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#193f1f"
-      - "#127723"
-      - "#89dfa4"
-      - "#ffffe0"
-      - "#ffa555"
-      - "#d76523"
-      breaks:
-      - -50000
-      - -15000
-      - -5000
-      - 5000
-      - 15000
+    legend: balance-housjobs0016-county
+    layers:
+    - id: balance-housjobs0016-county
+      type: choropleth
+      source: balance-housjobs0016
+      source-layer: balance-housjobs0016-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#193f1f"
+        - "#127723"
+        - "#89dfa4"
+        - "#ffffe0"
+        - "#ffa555"
+        - "#d76523"
+        breaks:
+        - -50000
+        - -15000
+        - -5000
+        - 5000
+        - 15000

--- a/cms/maps/balance-housjobs0016.yaml
+++ b/cms/maps/balance-housjobs0016.yaml
@@ -17,9 +17,9 @@ map:
     type: cartovector
     source-layers:
     - id: balance-housjobs0016-subregion
-      sql: SELECT the_geom_webmercator, geoid, balhpj0016 as value FROM region_subregion_v0
+      sql: SELECT the_geom_webmercator, geoid, balhpj0016 as value, name FROM region_subregion_v0
     - id: balance-housjobs0016-county
-      sql: SELECT the_geom_webmercator, geoid, balhpj0016 as value FROM region_county_v0
+      sql: SELECT the_geom_webmercator, geoid, balhpj0016 as value, name FROM region_county_v0
 
   popupColumns:
   - id: balhpj0016

--- a/cms/maps/balance-housjobs16.yaml
+++ b/cms/maps/balance-housjobs16.yaml
@@ -17,9 +17,9 @@ map:
     type: cartovector
     source-layers:
     - id: balance-housjobs16-subregion
-      sql: SELECT the_geom_webmercator, geoid, balhj16 as value FROM region_subregion_v0
+      sql: SELECT the_geom_webmercator, geoid, balhj16 as value, name FROM region_subregion_v0
     - id: balance-housjobs16-county
-      sql: SELECT the_geom_webmercator, geoid, balhj16 as value FROM region_county_v0
+      sql: SELECT the_geom_webmercator, geoid, balhj16 as value, name FROM region_county_v0
 
   popupColumns:
   - id: balhj16

--- a/cms/maps/balance-housjobs16.yaml
+++ b/cms/maps/balance-housjobs16.yaml
@@ -10,14 +10,7 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: balance-housjobs16-subregion
-    type: subregion
-  - layerId: balance-housjobs16-county
-    type: county
-
   defaultGeographyLevel: county
-  # TODO: Confirm defaultGeographyLevel; it's not defined in spreadsheet
 
   sources:
   - id: balance-housjobs16
@@ -49,44 +42,50 @@ map:
   isPercent: false
   isChangeMeasurement: false
 
-  layers:
-  - id: balance-housjobs16-subregion
+  layerGroups:
+  - id: subregion
     title: "Housing Units/Total Employment 2016"
-    type: choropleth
-    source: balance-housjobs16
-    source-layer: balance-housjobs16-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#127723"
-      - "#89dfa4"
-      - "#ffffe0"
-      - "#ffa555"
-      - "#d76523"
-      breaks:
-      - 0.825
-      - 0.850
-      - 0.9
-      - 0.95
-  - id: balance-housjobs16-county
+    legend: balance-housjobs16-subregion
+    layers:
+    - id: balance-housjobs16-subregion
+      type: choropleth
+      source: balance-housjobs16
+      source-layer: balance-housjobs16-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#127723"
+        - "#89dfa4"
+        - "#ffffe0"
+        - "#ffa555"
+        - "#d76523"
+        breaks:
+        - 0.825
+        - 0.850
+        - 0.9
+        - 0.95
+  - id: county
     title: "Housing Units/Total Employment 2016"
-    type: choropleth
-    source: balance-housjobs16
-    source-layer: balance-housjobs16-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#193f1f"
-      - "#127723"
-      - "#89dfa4"
-      - "#ffffe0"
-      - "#ffa555"
-      - "#d76523"
-      - "#87390c"
-      breaks:
-      - 0.4
-      - 0.6
-      - 0.85
-      - 0.9
-      - 1.15
-      - 1.75
+    legend: balance-housjobs16-county
+    layers:
+    - id: balance-housjobs16-county
+      type: choropleth
+      source: balance-housjobs16
+      source-layer: balance-housjobs16-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#193f1f"
+        - "#127723"
+        - "#89dfa4"
+        - "#ffffe0"
+        - "#ffa555"
+        - "#d76523"
+        - "#87390c"
+        breaks:
+        - 0.4
+        - 0.6
+        - 0.85
+        - 0.9
+        - 1.15
+        - 1.75

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: multifamily-permitted-subregion
-    type: subregion
-  - layerId: multifamily-permitted-county
-    type: county
-  - layerId: multifamily-permitted-municipality
-    type: municipality
-
   defaultGeographyLevel: county
 
   sources:
@@ -30,6 +22,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, houps1016 as value, name FROM region_county_v0
     - id: multifamily-permitted-municipality
       sql: SELECT the_geom_webmercator, random_value FROM region_unittype_dotdensity_v2
+    - id: empty-polygons-municipality
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: houps
@@ -57,67 +51,89 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: multifamily-permitted-subregion
+  layerGroups:
+  - id: subregion
     title: "Housing Units Permitted, 2010-2016"
-    type: choropleth
-    source: multifamily-permitted
-    source-layer: multifamily-permitted-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 10000
-      - 20000
-      - 50000
-      - 100000
-  - id: multifamily-permitted-county
+    legend: multifamily-permitted-subregion
+    layers:
+    - id: multifamily-permitted-subregion
+      type: choropleth
+      source: multifamily-permitted
+      source-layer: multifamily-permitted-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 10000
+        - 20000
+        - 50000
+        - 100000
+  - id: county
     title: "Housing Units Permitted, 2010-2016"
-    type: choropleth
-    source: multifamily-permitted
-    source-layer: multifamily-permitted-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 3000
-      - 7500
-      - 15000
-      - 30000
-  - id: multifamily-permitted-municipality
+    legend: multifamily-permitted-county
+    layers:
+    - id: multifamily-permitted-county
+      type: choropleth
+      source: multifamily-permitted
+      source-layer: multifamily-permitted-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 3000
+        - 7500
+        - 15000
+        - 30000
+  - id: municipality
     title: "Single vs. Multifamily Housing Units Permitted, 2010-2016"
-    type: circle
-    legend:
-    - color: "#fc8d59"
-      label: "50 Single-family Units"
-    - color: "#91bfdb"
-      label: "50 Multi-family Units"
-    source: multifamily-permitted
-    source-layer: multifamily-permitted-municipality
-    paint:
-      circle-color:
-      - match
-      - - get
-        - random_value
-      - "single"
-      - "#fc8d59"
-      - "multi"
-      - "#91bfdb"
-      - "#FFFFFF"
-      circle-radius:
-        stops:
-        - - 7
-          - 1.5
-        - - 11
-          - 2
-      circle-opacity: 0.9
+    legend: multifamily-permitted-municipality
+    layers:
+    - id: multifamily-permitted-municipality
+      type: circle
+      legend:
+      - color: "#fc8d59"
+        label: "50 Single-family Units"
+      - color: "#91bfdb"
+        label: "50 Multi-family Units"
+      source: multifamily-permitted
+      source-layer: multifamily-permitted-municipality
+      paint:
+        circle-color:
+        - match
+        - - get
+          - random_value
+        - "single"
+        - "#fc8d59"
+        - "multi"
+        - "#91bfdb"
+        - "#FFFFFF"
+        circle-radius:
+          stops:
+          - - 7
+            - 1.5
+          - - 11
+            - 2
+        circle-opacity: 0.9
+    - id: empty-municipality-polygons
+      type: fill
+      source: multifamily-permitted
+      source-layer: empty-polygons-municipality
+      paint:
+        fill-opacity: 0
+    - id: empty-municipality-line
+      type: line
+      source: multifamily-permitted
+      source-layer: empty-polygons-municipality
+      paint:
+        line-color: rgba(131, 131, 131, 1)
+        line-width: 0.5

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -23,7 +23,7 @@ map:
 
   popupColumns:
   - id: owner
-    title: Units
+    title: Owner-occupied
     large: true
     values:
     - geomType: region
@@ -62,7 +62,7 @@ map:
       cv: houo16cv
       sig:
   - id: renter
-    title: Units
+    title: Renter-occupied
     large: true
     values:
     - geomType: region

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -10,10 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: renter-owner-municipality
-    type: municipality
-
   defaultGeographyLevel: municipality
 
   sources:
@@ -22,6 +18,8 @@ map:
     source-layers:
     - id: renter-owner-municipality
       sql: SELECT the_geom_webmercator, random_value FROM region_tenure_dotdensity_v0
+    - id: empty-polygons-municipality
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: owner
@@ -105,31 +103,46 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: renter-owner-municipality
+  layerGroups:
+  - id: municipality
     title: "Housing Units by Renter vs. Owner, 2012-2016 Avg"
-    type: circle
-    source: renter-owner
-    source-layer: renter-owner-municipality
     legend:
     - color: "#fc8d59"
       label: "50 Owner-occupied Units"
     - color: "#91bfdb"
       label: "50 Renter-occupied Units"
-    paint:
-      circle-color:
-      - match
-      - - get
-        - random_value
-      - "own"
-      - "#fc8d59"
-      - "rent"
-      - "#91bfdb"
-      - "#FFFFFF"
-      circle-radius:
-        stops:
-        - - 7
-          - 1.5
-        - - 11
-          - 2
-      circle-opacity: 0.4
+    layers:
+    - id: renter-owner-municipality
+      type: circle
+      source: renter-owner
+      source-layer: renter-owner-municipality
+      paint:
+        circle-color:
+        - match
+        - - get
+          - random_value
+        - "own"
+        - "#fc8d59"
+        - "rent"
+        - "#91bfdb"
+        - "#FFFFFF"
+        circle-radius:
+          stops:
+          - - 7
+            - 1.5
+          - - 11
+            - 2
+        circle-opacity: 0.4
+    - id: empty-municipality-polygons
+      type: fill
+      source: renter-owner
+      source-layer: empty-polygons-municipality
+      paint:
+        fill-opacity: 0
+    - id: empty-municipality-line
+      type: line
+      source: renter-owner
+      source-layer: empty-polygons-municipality
+      paint:
+        line-color: rgba(131, 131, 131, 1)
+        line-width: 0.5

--- a/cms/maps/housing-total-units.yaml
+++ b/cms/maps/housing-total-units.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: total-units-subregion
-    type: subregion
-  - layerId: total-units-county
-    type: county
-  - layerId: total-units-municipality
-    type: municipality
-
   defaultGeographyLevel: municipality
 
   sources:
@@ -74,58 +66,67 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: total-units-subregion
+  layerGroups:
+  - id: subregion
     title: "Total Housing Units, 2012-2016 Avg"
-    type: choropleth
-    source: total-units
-    source-layer: total-units-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 500000
-      - 750000
-      - 1000000
-      - 2000000
-  - id: total-units-county
+    legend: total-units-subregion
+    layers:
+    - id: total-units-subregion
+      type: choropleth
+      source: total-units
+      source-layer: total-units-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 500000
+        - 750000
+        - 1000000
+        - 2000000
+  - id: county
     title: "Total Housing Units, 2012-2016 Avg"
-    type: choropleth
-    source: total-units
-    source-layer: total-units-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 50000
-      - 100000
-      - 250000
-      - 500000
-  - id: total-units-municipality
+    legend: total-units-county
+    layers:
+    - id: total-units-county
+      type: choropleth
+      source: total-units
+      source-layer: total-units-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 50000
+        - 100000
+        - 250000
+        - 500000
+  - id: municipality
     title: "Total Housing Units, 2012-2016 Avg"
-    type: choropleth
-    source: total-units
-    source-layer: total-units-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 1000
-      - 5000
-      - 15000
-      - 50000
+    legend: total-units-municipality
+    layers:
+    - id: total-units-municipality
+      type: choropleth
+      source: total-units
+      source-layer: total-units-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 1000
+        - 5000
+        - 15000
+        - 50000

--- a/cms/maps/housing-units-permitted.yaml
+++ b/cms/maps/housing-units-permitted.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: units-permitted-subregion
-    type: subregion
-  - layerId: units-permitted-county
-    type: county
-  - layerId: units-permitted-municipality
-    type: municipality
-
   defaultGeographyLevel: county
 
   sources:
@@ -57,58 +49,67 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: units-permitted-subregion
+  layerGroups:
+  - id: subregion
     title: "Housing Units Permitted, 2010-2016"
-    type: choropleth
-    source: units-permitted
-    source-layer: units-permitted-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 10000
-      - 20000
-      - 50000
-      - 100000
-  - id: units-permitted-county
+    legend: units-permitted-subregion
+    layers:
+    - id: units-permitted-subregion
+      type: choropleth
+      source: units-permitted
+      source-layer: units-permitted-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 10000
+        - 20000
+        - 50000
+        - 100000
+  - id: county
     title: "Housing Units Permitted, 2010-2016"
-    type: choropleth
-    source: units-permitted
-    source-layer: units-permitted-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 3000
-      - 7500
-      - 15000
-      - 30000
-  - id: units-permitted-municipality
+    legend: units-permitted-county
+    layers:
+    - id: units-permitted-county
+      type: choropleth
+      source: units-permitted
+      source-layer: units-permitted-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 3000
+        - 7500
+        - 15000
+        - 30000
+  - id: municipality
     title: "Housing Units Permitted, 2010-2016"
-    type: choropleth
-    source: units-permitted
-    source-layer: units-permitted-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#ffffbe"
-      - "#ffd37f"
-      - "#ffaa00"
-      - "#ff5500"
-      breaks:
-      - 500
-      - 1000
-      - 2500
-      - 5000
+    legend: units-permitted-municipality
+    layers:
+    - id: units-permitted-municipality
+      type: choropleth
+      source: units-permitted
+      source-layer: units-permitted-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#ffffbe"
+        - "#ffd37f"
+        - "#ffaa00"
+        - "#ff5500"
+        breaks:
+        - 500
+        - 1000
+        - 2500
+        - 5000

--- a/cms/maps/introduction.yaml
+++ b/cms/maps/introduction.yaml
@@ -76,6 +76,10 @@ map:
         - rgba(34, 60, 119, 1)
         - "#FFFFFF"
         fill-antialias: true
+  - id: municipality
+    title:
+    legend:
+    layers:
     - id: empty-polygons-municipality
       title:
       type: fill

--- a/cms/maps/introduction.yaml
+++ b/cms/maps/introduction.yaml
@@ -8,14 +8,6 @@ content: |
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 map:
-  toggles:
-  - layerId: empty-polygons-subregion
-    type: subregion
-  - layerId: empty-polygons-county
-    type: county
-  - layerId: empty-polygons-municipality
-    type: municipality
-
   defaultGeographyLevel: county
 
   sources:
@@ -29,76 +21,82 @@ map:
       - id: empty-polygons-municipality
         sql: SELECT the_geom_webmercator, geoid, (cartodb_id % 5) AS color, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
-  layers:
-  - id: empty-polygons-subregion
+  layerGroups:
+  - id: subregion
     title:
-    type: fill
-    source: empty-polygons
-    source-layer: empty-polygons-subregion
-    paint:
-      fill-outline-color: rgba(0, 0, 0, 1)
-      fill-opacity: 0.6
-      fill-color:
-      - match
-      - - get
-        - color
-      - 0
-      - rgba(67, 114, 222, 1)
-      - 1
-      - rgba(56, 98, 193, 1)
-      - 2
-      - rgba(48, 85, 167, 1)
-      - 3
-      - rgba(41, 72, 142, 1)
-      - 4
-      - rgba(34, 60, 119, 1)
-      - "#FFFFFF"
-      fill-antialias: true
-  - id: empty-polygons-county
+    legend:
+    layers:
+    - id: empty-polygons-subregion
+      type: fill
+      source: empty-polygons
+      source-layer: empty-polygons-subregion
+      paint:
+        fill-outline-color: rgba(0, 0, 0, 1)
+        fill-opacity: 0.6
+        fill-color:
+        - match
+        - - get
+          - color
+        - 0
+        - rgba(67, 114, 222, 1)
+        - 1
+        - rgba(56, 98, 193, 1)
+        - 2
+        - rgba(48, 85, 167, 1)
+        - 3
+        - rgba(41, 72, 142, 1)
+        - 4
+        - rgba(34, 60, 119, 1)
+        - "#FFFFFF"
+        fill-antialias: true
+  - id: county
     title:
-    type: fill
-    source: empty-polygons
-    source-layer: empty-polygons-county
-    paint:
-      fill-outline-color: rgba(0, 0, 0, 1)
-      fill-opacity: 0.6
-      fill-color:
-      - match
-      - - get
-        - color
-      - 0
-      - rgba(67, 114, 222, 1)
-      - 1
-      - rgba(56, 98, 193, 1)
-      - 2
-      - rgba(48, 85, 167, 1)
-      - 3
-      - rgba(41, 72, 142, 1)
-      - 4
-      - rgba(34, 60, 119, 1)
-      - "#FFFFFF"
-      fill-antialias: true
-  - id: empty-polygons-municipality
-    title:
-    type: fill
-    source: empty-polygons
-    source-layer: empty-polygons-municipality
-    paint:
-      fill-outline-color: rgba(0, 0, 0, 1)
-      fill-opacity: 0.6
-      fill-color:
-      - match
-      - - get
-        - color
-      - 0
-      - rgba(67, 114, 222, 1)
-      - 1
-      - rgba(56, 98, 193, 1)
-      - 2
-      - rgba(48, 85, 167, 1)
-      - 3
-      - rgba(41, 72, 142, 1)
-      - 4
-      - rgba(34, 60, 119, 1)
-      - "#FFFFFF"
-      fill-antialias: true
+    legend:
+    layers:
+    - id: empty-polygons-county
+      type: fill
+      source: empty-polygons
+      source-layer: empty-polygons-county
+      paint:
+        fill-outline-color: rgba(0, 0, 0, 1)
+        fill-opacity: 0.6
+        fill-color:
+        - match
+        - - get
+          - color
+        - 0
+        - rgba(67, 114, 222, 1)
+        - 1
+        - rgba(56, 98, 193, 1)
+        - 2
+        - rgba(48, 85, 167, 1)
+        - 3
+        - rgba(41, 72, 142, 1)
+        - 4
+        - rgba(34, 60, 119, 1)
+        - "#FFFFFF"
+        fill-antialias: true
+    - id: empty-polygons-municipality
+      title:
+      type: fill
+      source: empty-polygons
+      source-layer: empty-polygons-municipality
+      paint:
+        fill-outline-color: rgba(0, 0, 0, 1)
+        fill-opacity: 0.6
+        fill-color:
+        - match
+        - - get
+          - color
+        - 0
+        - rgba(67, 114, 222, 1)
+        - 1
+        - rgba(56, 98, 193, 1)
+        - 2
+        - rgba(48, 85, 167, 1)
+        - 3
+        - rgba(41, 72, 142, 1)
+        - 4
+        - rgba(34, 60, 119, 1)
+        - "#FFFFFF"
+        fill-antialias: true

--- a/cms/maps/jobs-industrial-employment.yaml
+++ b/cms/maps/jobs-industrial-employment.yaml
@@ -17,11 +17,11 @@ map:
     type: cartovector
     source-layers:
     - id: industrial-employment-subregion
-      sql: SELECT the_geom_webmercator, geoid, emind16 as value FROM region_subregion_v0
+      sql: SELECT the_geom_webmercator, geoid, emind16 as value, name FROM region_subregion_v0
     - id: industrial-employment-county
-      sql: SELECT the_geom_webmercator, geoid, emind16 as value FROM region_county_v0
+      sql: SELECT the_geom_webmercator, geoid, emind16 as value, name FROM region_county_v0
     - id: industrial-employment-municipality
-      sql: SELECT the_geom_webmercator, geoid, emind15 as value FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, emind15 as value, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: industrialemployment

--- a/cms/maps/jobs-industrial-employment.yaml
+++ b/cms/maps/jobs-industrial-employment.yaml
@@ -10,14 +10,6 @@ content: |
 source: U.S. Bureau of Labor Services, QCEW NAICS-based files, 2016; U.S. Census Bureau LEHD-LODES 2015
 
 map:
-  toggles:
-  - layerId: industrial-employment-subregion
-    type: subregion
-  - layerId: industrial-employment-county
-    type: county
-  - layerId: industrial-employment-municipality
-    type: municipality
-
   defaultGeographyLevel: subregion
 
   sources:
@@ -30,7 +22,6 @@ map:
       sql: SELECT the_geom_webmercator, geoid, emind16 as value FROM region_county_v0
     - id: industrial-employment-municipality
       sql: SELECT the_geom_webmercator, geoid, emind15 as value FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
-
 
   popupColumns:
   - id: industrialemployment
@@ -56,54 +47,63 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: industrial-employment-subregion
+  layerGroups:
+  - id: subregion
     title: "Private Industrial Employment 2016"
-    type: choropleth
-    source: industrial-employment
-    source-layer: industrial-employment-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#f5eaf7"
-      - "#d6a8e0"
-      - "#9e5dba"
-      - "#712d8e"
-      breaks:
-      - 100000
-      - 250000
-      - 500000
-  - id: industrial-employment-county
+    legend: industrial-employment-subregion
+    layers:
+    - id: industrial-employment-subregion
+      type: choropleth
+      source: industrial-employment
+      source-layer: industrial-employment-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#f5eaf7"
+        - "#d6a8e0"
+        - "#9e5dba"
+        - "#712d8e"
+        breaks:
+        - 100000
+        - 250000
+        - 500000
+  - id: county
     title: "Private Industrial Employment 2016"
-    type: choropleth
-    source: industrial-employment
-    source-layer: industrial-employment-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#f5eaf7"
-      - "#d6a8e0"
-      - "#9e5dba"
-      - "#712d8e"
-      breaks:
-      - 15000
-      - 50000
-      - 85000
-  - id: industrial-employment-municipality
+    legend: industrial-employment-county
+    layers:
+    - id: industrial-employment-county
+      type: choropleth
+      source: industrial-employment
+      source-layer: industrial-employment-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#f5eaf7"
+        - "#d6a8e0"
+        - "#9e5dba"
+        - "#712d8e"
+        breaks:
+        - 15000
+        - 50000
+        - 85000
+  - id: municipality
     title: "Private Industrial Employment 2015"
-    type: choropleth
-    source: industrial-employment
-    source-layer: industrial-employment-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#f5eaf7"
-      - "#d6a8e0"
-      - "#9e5dba"
-      - "#712d8e"
-      - "#401354"
-      breaks:
-      - 1000
-      - 5000
-      - 15000
-      - 50000
+    legend: industrial-employment-municipality
+    layers:
+    - id: industrial-employment-municipality
+      type: choropleth
+      source: industrial-employment
+      source-layer: industrial-employment-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#f5eaf7"
+        - "#d6a8e0"
+        - "#9e5dba"
+        - "#712d8e"
+        - "#401354"
+        breaks:
+        - 1000
+        - 5000
+        - 15000
+        - 50000

--- a/cms/maps/jobs-institutional-employment.yaml
+++ b/cms/maps/jobs-institutional-employment.yaml
@@ -17,11 +17,11 @@ map:
     type: cartovector
     source-layers:
     - id: institutional-employment-subregion
-      sql: SELECT the_geom_webmercator, geoid, emins16 as value FROM region_subregion_v0
+      sql: SELECT the_geom_webmercator, geoid, emins16 as value, name FROM region_subregion_v0
     - id: institutional-employment-county
-      sql: SELECT the_geom_webmercator, geoid, emins16 as value FROM region_county_v0
+      sql: SELECT the_geom_webmercator, geoid, emins16 as value, name FROM region_county_v0
     - id: institutional-employment-municipality
-      sql: SELECT the_geom_webmercator, geoid, emins15 as value FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, emins15 as value, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emins

--- a/cms/maps/jobs-institutional-employment.yaml
+++ b/cms/maps/jobs-institutional-employment.yaml
@@ -10,14 +10,6 @@ content: |
 source: U.S. Bureau of Labor Services, QCEW NAICS-based files, 2016; U.S. Census Bureau LEHD-LODES 2015
 
 map:
-  toggles:
-  - layerId: institutional-employment-subregion
-    type: subregion
-  - layerId: institutional-employment-county
-    type: county
-  - layerId: institutional-employment-municipality
-    type: municipality
-
   defaultGeographyLevel: subregion
 
   sources:
@@ -55,54 +47,63 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: institutional-employment-subregion
+  layerGroups:
+  - id: subregion
     title: "Total Institutional Employment 2016"
-    type: choropleth
-    source: institutional-employment
-    source-layer: institutional-employment-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#e8d699"
-      - "#e8c758"
-      - "#a87a10"
-      breaks:
-      - 100000
-      - 250000
-      - 500000
-  - id: institutional-employment-county
+    legend: institutional-employment-subregion
+    layers:
+    - id: institutional-employment-subregion
+      type: choropleth
+      source: institutional-employment
+      source-layer: institutional-employment-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#e8d699"
+        - "#e8c758"
+        - "#a87a10"
+        breaks:
+        - 100000
+        - 250000
+        - 500000
+  - id: county
     title: "Total Institutional Employment 2016"
-    type: choropleth
-    source: institutional-employment
-    source-layer: institutional-employment-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#e8d699"
-      - "#e8c758"
-      - "#a87a10"
-      breaks:
-      - 15000
-      - 50000
-      - 85000
-  - id: institutional-employment-municipality
+    legend: institutional-employment-county
+    layers:
+    - id: institutional-employment-county
+      type: choropleth
+      source: institutional-employment
+      source-layer: institutional-employment-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#e8d699"
+        - "#e8c758"
+        - "#a87a10"
+        breaks:
+        - 15000
+        - 50000
+        - 85000
+  - id: municipality
     title: "Total Institutional Employment 2015"
-    type: choropleth
-    source: institutional-employment
-    source-layer: institutional-employment-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffffe0"
-      - "#e8d699"
-      - "#e8c758"
-      - "#a87a10"
-      - "#7c5511"
-      breaks:
-      - 1000
-      - 5000
-      - 15000
-      - 50000
+    legend: institutional-employment-municipality
+    layers:
+    - id: institutional-employment-municipality
+      type: choropleth
+      source: institutional-employment
+      source-layer: institutional-employment-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffffe0"
+        - "#e8d699"
+        - "#e8c758"
+        - "#a87a10"
+        - "#7c5511"
+        breaks:
+        - 1000
+        - 5000
+        - 15000
+        - 50000

--- a/cms/maps/jobs-localserve-employment.yaml
+++ b/cms/maps/jobs-localserve-employment.yaml
@@ -10,14 +10,6 @@ content: |
 source: U.S. Bureau of Labor Services, QCEW NAICS-based files, 2016; U.S. Census Bureau LEHD-LODES 2015
 
 map:
-  toggles:
-  - layerId: localserve-employment-subregion
-    type: subregion
-  - layerId: localserve-employment-county
-    type: county
-  - layerId: localserve-employment-municipality
-    type: municipality
-
   defaultGeographyLevel: subregion
 
   sources:
@@ -25,11 +17,11 @@ map:
     type: cartovector
     source-layers:
     - id: localserve-employment-subregion
-      sql: SELECT the_geom_webmercator, geoid, emser16 as value FROM region_subregion_v0
+      sql: SELECT the_geom_webmercator, geoid, emser16 as value, name FROM region_subregion_v0
     - id: localserve-employment-county
-      sql: SELECT the_geom_webmercator, geoid, emser16 as value FROM region_county_v0
+      sql: SELECT the_geom_webmercator, geoid, emser16 as value, name FROM region_county_v0
     - id: localserve-employment-municipality
-      sql: SELECT the_geom_webmercator, geoid, emser15 as value FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, emser15 as value, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emser
@@ -55,54 +47,63 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: localserve-employment-subregion
+  layerGroups:
+  - id: subregion
     title: "Retail, Leisure & Hospitality Private Employment 2016"
-    type: choropleth
-    source: localserve-employment
-    source-layer: localserve-employment-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#dbfcdc"
-      - "#aaf7ac"
-      - "#3db709"
-      - "#2e7a0d"
-      breaks:
-      - 100000
-      - 250000
-      - 500000
-  - id: localserve-employment-county
+    legend: localserve-employment-subregion
+    layers:
+    - id: localserve-employment-subregion
+      type: choropleth
+      source: localserve-employment
+      source-layer: localserve-employment-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#dbfcdc"
+        - "#aaf7ac"
+        - "#3db709"
+        - "#2e7a0d"
+        breaks:
+        - 100000
+        - 250000
+        - 500000
+  - id: county
     title: "Retail, Leisure & Hospitality Private Employment 2016"
-    type: choropleth
-    source: localserve-employment
-    source-layer: localserve-employment-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#dbfcdc"
-      - "#aaf7ac"
-      - "#3db709"
-      - "#2e7a0d"
-      breaks:
-      - 15000
-      - 50000
-      - 85000
-  - id: localserve-employment-municipality
+    legend: localserve-employment-county
+    layers:
+    - id: localserve-employment-county
+      type: choropleth
+      source: localserve-employment
+      source-layer: localserve-employment-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#dbfcdc"
+        - "#aaf7ac"
+        - "#3db709"
+        - "#2e7a0d"
+        breaks:
+        - 15000
+        - 50000
+        - 85000
+  - id: municipality
     title: "Retail, Leisure & Hospitality Private Employment 2015"
-    type: choropleth
-    source: localserve-employment
-    source-layer: localserve-employment-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#dbfcdc"
-      - "#aaf7ac"
-      - "#3db709"
-      - "#2e7a0d"
-      - "#173d07"
-      breaks:
-      - 1000
-      - 5000
-      - 15000
-      - 50000
+    legend: localserve-employment-municipality
+    layers:
+    - id: localserve-employment-municipality
+      type: choropleth
+      source: localserve-employment
+      source-layer: localserve-employment-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#dbfcdc"
+        - "#aaf7ac"
+        - "#3db709"
+        - "#2e7a0d"
+        - "#173d07"
+        breaks:
+        - 1000
+        - 5000
+        - 15000
+        - 50000

--- a/cms/maps/jobs-office-employment.yaml
+++ b/cms/maps/jobs-office-employment.yaml
@@ -10,14 +10,6 @@ content: |
 source: U.S. Bureau of Labor Services, QCEW NAICS-based files, 2016; U.S. Census Bureau LEHD-LODES 2015
 
 map:
-  toggles:
-  - layerId: office-employment-subregion
-    type: subregion
-  - layerId: office-employment-county
-    type: county
-  - layerId: office-employment-municipality
-    type: municipality
-
   defaultGeographyLevel: subregion
 
   sources:
@@ -55,54 +47,63 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: office-employment-subregion
+  layerGroups:
+  - id: subregion
     title: "Office-based Private Employment 2016"
-    type: choropleth
-    source: office-employment
-    source-layer: office-employment-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ccffff"
-      - "#00ffff"
-      - "#179FA5"
-      - "#115459"
-      breaks:
-      - 100000
-      - 250000
-      - 500000
-  - id: office-employment-county
+    legend: office-employment-subregion
+    layers:
+    - id: office-employment-subregion
+      type: choropleth
+      source: office-employment
+      source-layer: office-employment-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ccffff"
+        - "#00ffff"
+        - "#179FA5"
+        - "#115459"
+        breaks:
+        - 100000
+        - 250000
+        - 500000
+  - id: county
     title: "Office-based Private Employment 2016"
-    type: choropleth
-    source: office-employment
-    source-layer: office-employment-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ccffff"
-      - "#00ffff"
-      - "#179FA5"
-      - "#115459"
-      breaks:
-      - 15000
-      - 50000
-      - 85000
-  - id: office-employment-municipality
+    legend: office-employment-county
+    layers:
+    - id: office-employment-county
+      type: choropleth
+      source: office-employment
+      source-layer: office-employment-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ccffff"
+        - "#00ffff"
+        - "#179FA5"
+        - "#115459"
+        breaks:
+        - 15000
+        - 50000
+        - 85000
+  - id: municipality
     title: "Office-based Private Employment 2015"
-    type: choropleth
-    source: office-employment
-    source-layer: office-employment-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ccffff"
-      - "#00ffff"
-      - "#179FA5"
-      - "#115459"
-      - "#0d1923"
-      breaks:
-      - 1000
-      - 5000
-      - 15000
-      - 50000
+    legend: office-employment-municipality
+    layers:
+    - id: office-employment-municipality
+      type: choropleth
+      source: office-employment
+      source-layer: office-employment-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ccffff"
+        - "#00ffff"
+        - "#179FA5"
+        - "#115459"
+        - "#0d1923"
+        breaks:
+        - 1000
+        - 5000
+        - 15000
+        - 50000

--- a/cms/maps/jobs-private-employment-change.yaml
+++ b/cms/maps/jobs-private-employment-change.yaml
@@ -10,12 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: private-employment-change-subregion
-    type: subregion
-  - layerId: private-employment-change-county
-    type: county
-
   defaultGeographyLevel: county
   # TODO: Confirm defaultGeographyLevel; it's not defined in spreadsheet
 
@@ -49,44 +43,50 @@ map:
   isPercent: false
   isChangeMeasurement: true
 
-  layers:
-  - id: private-employment-change-subregion
+  layerGroups:
+  - id: subregion
     title: "Private Employment Change, 2008-2016"
-    type: choropleth
-    source: private-employment-change
-    source-layer: private-employment-change-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffa555"
-      - "#ffffe0"
-      - "#89dfa4"
-      - "#127723"
-      - "#193f1f"
-      breaks:
-      - 10000
-      - 50000
-      - 100000
-      - 300000
-  - id: private-employment-change-county
+    legend: private-employment-change-county
+    layers:
+    - id: private-employment-change-subregion
+      type: choropleth
+      source: private-employment-change
+      source-layer: private-employment-change-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffa555"
+        - "#ffffe0"
+        - "#89dfa4"
+        - "#127723"
+        - "#193f1f"
+        breaks:
+        - 10000
+        - 50000
+        - 100000
+        - 300000
+  - id: county
     title: "Private Employment Change, 2008-2016"
-    type: choropleth
-    source: private-employment-change
-    source-layer: private-employment-change-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d76423"
-      - "#ffa555"
-      - "#ffffe0"
-      - "#89dfa4"
-      - "#127723"
-      - "#193f1f"
-      - "#031c0d"
-      breaks:
-      - -10000
-      - -2500
-      - 2500
-      - 15000
-      - 35000
-      - 100000
+    legend: private-employment-change-county
+    layers:
+    - id: private-employment-change-county
+      type: choropleth
+      source: private-employment-change
+      source-layer: private-employment-change-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d76423"
+        - "#ffa555"
+        - "#ffffe0"
+        - "#89dfa4"
+        - "#127723"
+        - "#193f1f"
+        - "#031c0d"
+        breaks:
+        - -10000
+        - -2500
+        - 2500
+        - 15000
+        - 35000
+        - 100000

--- a/cms/maps/jobs-total-employment.yaml
+++ b/cms/maps/jobs-total-employment.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: total-employment-subregion
-    type: subregion
-  - layerId: total-employment-county
-    type: county
-  - layerId: total-employment-municipality
-    type: municipality
-
   defaultGeographyLevel: subregion
 
   sources:
@@ -55,58 +47,67 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: total-employment-subregion
+  layerGroups:
+  - id: subregion
     title: "Total Employment 2016"
-    type: choropleth
-    source: total-employment
-    source-layer: total-employment-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ccf5df"
-      - "#89dfa4"
-      - "#64b678"
-      - "#127723"
-      - "#193f1f"
-      breaks:
-      - 500000
-      - 750000
-      - 1000000
-      - 2500000
-  - id: total-employment-county
+    legend: total-employment-subregion
+    layers:
+    - id: total-employment-subregion
+      type: choropleth
+      source: total-employment
+      source-layer: total-employment-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ccf5df"
+        - "#89dfa4"
+        - "#64b678"
+        - "#127723"
+        - "#193f1f"
+        breaks:
+        - 500000
+        - 750000
+        - 1000000
+        - 2500000
+  - id: county
     title: "Total Employment 2016"
-    type: choropleth
-    source: total-employment
-    source-layer: total-employment-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ccf5df"
-      - "#89dfa4"
-      - "#64b678"
-      - "#127723"
-      - "#193f1f"
-      breaks:
-      - 100000
-      - 250000
-      - 500000
-      - 750000
-  - id: total-employment-municipality
+    legend: total-employment-county
+    layers:
+    - id: total-employment-county
+      type: choropleth
+      source: total-employment
+      source-layer: total-employment-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ccf5df"
+        - "#89dfa4"
+        - "#64b678"
+        - "#127723"
+        - "#193f1f"
+        breaks:
+        - 100000
+        - 250000
+        - 500000
+        - 750000
+  - id: municipality
     title: "Total Employment 2016"
-    type: choropleth
-    source: total-employment
-    source-layer: total-employment-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ccf5df"
-      - "#89dfa4"
-      - "#64b678"
-      - "#127723"
-      - "#193f1f"
-      breaks:
-      - 5000
-      - 10000
-      - 25000
-      - 50000
+    legend: total-employment-municipality
+    layers:
+    - id: total-employment-municipality
+      type: choropleth
+      source: total-employment
+      source-layer: total-employment-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ccf5df"
+        - "#89dfa4"
+        - "#64b678"
+        - "#127723"
+        - "#193f1f"
+        breaks:
+        - 5000
+        - 10000
+        - 25000
+        - 50000

--- a/cms/maps/people-foreign-born.yaml
+++ b/cms/maps/people-foreign-born.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: foreign-born-subregion
-    type: subregion
-  - layerId: foreign-born-county
-    type: county
-  - layerId: foreign-born-municipality
-    type: municipality
-
   defaultGeographyLevel: municipality
 
   sources:
@@ -74,46 +66,53 @@ map:
 
   isPercent: true
 
-  layers:
-  - id: foreign-born-subregion
+  layerGroups:
+  - id: subregion
     title: "Foreign Born as Share of Total Population, 2012-2016 Avg"
-    type: choropleth
-    source: foreign-born
-    source-layer: foreign-born-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#0094ff"
-      - "#002673"
-      breaks:
-      - 0.15
-      - 0.3
-  - id: foreign-born-county
+    layers:
+    - id: foreign-born-subregion
+      type: choropleth
+      source: foreign-born
+      source-layer: foreign-born-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#0094ff"
+        - "#002673"
+        breaks:
+        - 0.15
+        - 0.3
+  - id: county
     title: "Foreign Born as Share of Total Population, 2012-2016 Avg"
-    type: choropleth
-    source: foreign-born
-    source-layer: foreign-born-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#0094ff"
-      - "#002673"
-      breaks:
-      - 0.15
-      - 0.3
-  - id: foreign-born-municipality
+    layers:
+    - id: foreign-born-county
+      type: choropleth
+      source: foreign-born
+      source-layer: foreign-born-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#0094ff"
+        - "#002673"
+        breaks:
+        - 0.15
+        - 0.3
+  - id: municipality
     title: "Foreign Born as Share of Total Population, 2012-2016 Avg"
-    type: choropleth
-    source: foreign-born
-    source-layer: foreign-born-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#0094ff"
-      - "#002673"
-      breaks:
-      - 0.15
-      - 0.3
+    legend: foreign-born-municipality
+    layers:
+    - id: foreign-born-municipality
+      type: choropleth
+      source: foreign-born
+      source-layer: foreign-born-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#0094ff"
+        - "#002673"
+        breaks:
+        - 0.15
+        - 0.3

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -10,17 +10,7 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: net-population-change-subregion
-    type: subregion
-  - layerId: net-population-change-county
-    type: county
-  - layerId: net-population-change-municipality
-    type: municipality
-
-  defaultGeographyLevel: county
-  # TODO: change defaultGeographyLevel to municipality once dot density is in
-
+  defaultGeographyLevel: municipality
   sources:
   - id: net-population-change
     type: cartovector
@@ -29,8 +19,10 @@ map:
       sql: SELECT the_geom_webmercator, geoid, pop1016 as value, name FROM region_subregion_v0
     - id: net-population-change-county
       sql: SELECT the_geom_webmercator, geoid, pop1016 as value, name FROM region_county_v0
-    - id: net-population-change-municipality
+    - id: net-population-change-municipality-dotdensity
       sql: SELECT the_geom_webmercator, popa1016, popa1016si as value FROM region_popa1016_dotdensity_v0
+    - id: empty-polygons-municipality
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: change
@@ -76,67 +68,89 @@ map:
   isPercent: false
   isChangeMeasurement: true
 
-  layers:
-  - id: net-population-change-subregion
+  # Layergroups
+
+  layerGroups:
+  - id: subregion
     title: "Net Population Change, 2010 - 2016"
-    type: choropleth
-    source: net-population-change
-    source-layer: net-population-change-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffa555"
-      - "#ffffe0"
-      - "#b3e4ff"
-      - "#5ab4ff"
-      - "#002673"
-      breaks:
-      - -1500
-      - 5000
-      - 25000
-      - 100000
-  - id: net-population-change-county
+    legend: net-population-change-subregion
+    layers:
+    - id: net-population-change-subregion
+      type: choropleth
+      source: net-population-change
+      source-layer: net-population-change-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffa555"
+        - "#ffffe0"
+        - "#b3e4ff"
+        - "#5ab4ff"
+        - "#002673"
+        breaks:
+        - -1500
+        - 5000
+        - 25000
+        - 100000
+  - id: county
     title: "Net Population Change, 2010 - 2016"
-    type: choropleth
-    source: net-population-change
-    source-layer: net-population-change-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d76423"
-      - "#ffa555"
-      - "#ffffe0"
-      - "#b3e4ff"
-      - "#5ab4ff"
-      - "#002673"
-      breaks:
-      - -5000
-      - 1500
-      - 15000
-      - 50000
-  # TODO: add dot density layer config
-  - id: net-population-change-municipality
+    legend: net-population-change-county
+    layers:
+    - id: net-population-change-county
+      type: choropleth
+      source: net-population-change
+      source-layer: net-population-change-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d76423"
+        - "#ffa555"
+        - "#ffffe0"
+        - "#b3e4ff"
+        - "#5ab4ff"
+        - "#002673"
+        breaks:
+        - -5000
+        - 1500
+        - 15000
+        - 50000
+  - id: municipality
     title: "Net Population Change, 2010 - 2016"
-    type: circle
     legend:
     - color: "#ff7900"
       label: "Loss of 50 people"
     - color: "#00aacc"
       label: "Gain of 50 people"
-    source: net-population-change
-    source-layer: net-population-change-municipality
-    paint:
-      circle-color:
-      - step
-      - - get
-        - popa1016
-      - "#ff7900"
-      - 0
-      - "#00aacc"
-      circle-radius:
-        stops:
-        - - 7
-          - 1.5
-        - - 11
-          - 2
-      circle-opacity: 0.6
+    layers:
+    - id: net-population-change-municipality
+      type: circle
+      source: net-population-change
+      source-layer: net-population-change-municipality-dotdensity
+      paint:
+        circle-color:
+        - step
+        - - get
+          - popa1016
+        - "#ff7900"
+        - 0
+        - "#00aacc"
+        circle-radius:
+          stops:
+          - - 7
+            - 1.5
+          - - 11
+            - 2
+        circle-opacity: 0.6
+    - id: empty-municipality-polygons
+      type: fill
+      source: net-population-change
+      source-layer: empty-polygons-municipality
+      paint:
+        fill-opacity: 0
+    - id: empty-municipality-line
+      type: line
+      source: net-population-change
+      source-layer: empty-polygons-municipality
+      paint:
+        line-color: rgba(131, 131, 131, 1)
+        line-width: 0.5

--- a/cms/maps/people-population-change.yaml
+++ b/cms/maps/people-population-change.yaml
@@ -10,12 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: population-change-subregion
-    type: subregion
-  - layerId: population-change-county
-    type: county
-
   defaultGeographyLevel: county
 
   sources:
@@ -48,42 +42,48 @@ map:
   isPercent: true
   isChangeMeasurement: true
 
-  layers:
-  - id: population-change-subregion
+  layerGroups:
+  - id: subregion
     title: "% Population Change, 2010-2016"
-    type: choropleth
-    source: population-change
-    source-layer: population-change-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#ffa555"
-      - "#ffffe0"
-      - "#73efff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - 0
-      - 0.005
-      - 0.01
-      - 0.03
-  - id: population-change-county
+    legend: population-change-subregion
+    layers:
+    - id: population-change-subregion
+      type: choropleth
+      source: population-change
+      source-layer: population-change-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#ffa555"
+        - "#ffffe0"
+        - "#73efff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - 0
+        - 0.005
+        - 0.01
+        - 0.03
+  - id: county
     title: "% Population Change, 2010-2016"
-    type: choropleth
-    source: population-change
-    source-layer: population-change-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d76423"
-      - "#ffa555"
-      - "#ffffe0"
-      - "#73efff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - -0.025
-      - -0.01
-      - 0.01
-      - 0.025
-      - 0.05
+    legend: population-change-county
+    layers:
+    - id: population-change-county
+      type: choropleth
+      source: population-change
+      source-layer: population-change-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d76423"
+        - "#ffa555"
+        - "#ffffe0"
+        - "#73efff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - -0.025
+        - -0.01
+        - 0.01
+        - 0.025
+        - 0.05

--- a/cms/maps/people-population-density.yaml
+++ b/cms/maps/people-population-density.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: population-density-subregion
-    type: subregion
-  - layerId: population-density-county
-    type: county
-  - layerId: population-density-municipality
-    type: municipality
-
   defaultGeographyLevel: municipality
 
   sources:
@@ -74,58 +66,67 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: population-density-subregion
+  layerGroups:
+  - id: subregion
     title: "Population Density (Pop/sq. mile) 2016"
-    type: choropleth
-    source: population-density
-    source-layer: population-density-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#73efff"
-      - "#0094ff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - 500
-      - 1000
-      - 2000
-      - 3000
-  - id: population-density-county
+    legend: population-density-subregion
+    layers:
+    - id: population-density-subregion
+      type: choropleth
+      source: population-density
+      source-layer: population-density-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#73efff"
+        - "#0094ff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - 500
+        - 1000
+        - 2000
+        - 3000
+  - id: county
     title: "Population Density (Pop/sq. mile) 2016"
-    type: choropleth
-    source: population-density
-    source-layer: population-density-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#73efff"
-      - "#0094ff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - 1000
-      - 2500
-      - 5000
-      - 10000
-  - id: population-density-municipality
+    legend: population-density-county
+    layers:
+    - id: population-density-county
+      type: choropleth
+      source: population-density
+      source-layer: population-density-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#73efff"
+        - "#0094ff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - 1000
+        - 2500
+        - 5000
+        - 10000
+  - id: municipality
     title: "Population Density (Pop/sq. mile) 2016"
-    type: choropleth
-    source: population-density
-    source-layer: population-density-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#73efff"
-      - "#0094ff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - 1000
-      - 5000
-      - 10000
-      - 25000
+    legend: population-density-municipality
+    layers:
+    - id: population-density-municipality
+      type: choropleth
+      source: population-density
+      source-layer: population-density-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#73efff"
+        - "#0094ff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - 1000
+        - 5000
+        - 10000
+        - 25000

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: prime-labor-force-gain-subregion
-    type: subregion
-  - layerId: prime-labor-force-gain-county
-    type: county
-  - layerId: prime-labor-force-gain-municipality
-    type: municipality
-
   defaultGeographyLevel: municipality
 
   sources:
@@ -30,6 +22,8 @@ map:
       sql: SELECT the_geom_webmercator, geoid, lfpw0016 as value, name FROM region_county_v0
     - id: prime-labor-force-gain-municipality
       sql: SELECT the_geom_webmercator, lfpw0016, lfpw0016si as value FROM region_lfpw0016_dotdensity_v0
+    - id: empty-polygons-municipality
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: pop
@@ -45,6 +39,10 @@ map:
       cv:
       sig: lfpw0016si
     - geomType: county
+      columnName: lfpw0016
+      cv:
+      sig: lfpw0016si
+    - geomType: municipality
       columnName: lfpw0016
       cv:
       sig: lfpw0016si
@@ -71,67 +69,88 @@ map:
   isPercent: false
   isChangeMeasurement: true
 
-  layers:
-  - id: prime-labor-force-gain-subregion
+  layerGroups:
+  - id: subregion
     title: "Prime Labor Force Change, 2000-2016"
-    type: choropleth
-    source: prime-labor-force-gain
-    source-layer: prime-labor-force-gain-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d76423"
-      - "#ffa555"
-      - "#ffffe0"
-      - "#b3e4ff"
-      - "#5ab4ff"
-      breaks:
-      - -25000
-      - -10000
-      - 10000
-      - 100000
-  - id: prime-labor-force-gain-county
+    legend: prime-labor-force-gain-subregion
+    layers:
+    - id: prime-labor-force-gain-subregion
+      type: choropleth
+      source: prime-labor-force-gain
+      source-layer: prime-labor-force-gain-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d76423"
+        - "#ffa555"
+        - "#ffffe0"
+        - "#b3e4ff"
+        - "#5ab4ff"
+        breaks:
+        - -25000
+        - -10000
+        - 10000
+        - 100000
+  - id: county
     title: "Prime Labor Force Change, 2000-2016"
-    type: choropleth
-    source: prime-labor-force-gain
-    source-layer: prime-labor-force-gain-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d76423"
-      - "#ffa555"
-      - "#ffffe0"
-      - "#b3e4ff"
-      - "#5ab4ff"
-      - "#002673"
-      breaks:
-      - -15000
-      - -2500
-      - 2500
-      - 15000
-      - 75000
-  - id: prime-labor-force-gain-municipality
+    legend: prime-labor-force-gain-county
+    layers:
+    - id: prime-labor-force-gain-county
+      type: choropleth
+      source: prime-labor-force-gain
+      source-layer: prime-labor-force-gain-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d76423"
+        - "#ffa555"
+        - "#ffffe0"
+        - "#b3e4ff"
+        - "#5ab4ff"
+        - "#002673"
+        breaks:
+        - -15000
+        - -2500
+        - 2500
+        - 15000
+        - 75000
+  - id: municipality
     title: "Prime Labor Force Change, 2000-2016"
-    type: circle
     legend:
     - color: "#ff7900"
       label: "Loss of 50 people"
     - color: "#00aacc"
-      label: "Gain of 50 people"
-    source: prime-labor-force-gain
-    source-layer: prime-labor-force-gain-municipality
-    paint:
-      circle-color:
-      - step
-      - - get
-        - lfpw0016
-      - "#ff7900"
-      - 0
-      - "#00aacc"
-      circle-radius:
-        stops:
-        - - 7
-          - 1.5
-        - - 11
-          - 2
-      circle-opacity: 0.6
+      label: "Gain of 50 people"    layers:
+    layers:
+    - id: prime-labor-force-gain-municipality
+      type: circle
+      source: prime-labor-force-gain
+      source-layer: prime-labor-force-gain-municipality
+      paint:
+        circle-color:
+        - step
+        - - get
+          - lfpw0016
+        - "#ff7900"
+        - 0
+        - "#00aacc"
+        circle-radius:
+          stops:
+          - - 7
+            - 1.5
+          - - 11
+            - 2
+        circle-opacity: 0.6
+    - id: empty-municipality-polygons
+      type: fill
+      source: prime-labor-force-gain
+      source-layer: empty-polygons-municipality
+      paint:
+        fill-opacity: 0
+    - id: empty-municipality-line
+      type: line
+      source: prime-labor-force-gain
+      source-layer: empty-polygons-municipality
+      paint:
+        line-color: rgba(131, 131, 131, 1)
+        line-width: 0.5

--- a/cms/maps/people-total-population.yaml
+++ b/cms/maps/people-total-population.yaml
@@ -10,14 +10,6 @@ content: |
 source: This maps show data from some source.
 
 map:
-  toggles:
-  - layerId: total-population-subregion
-    type: subregion
-  - layerId: total-population-county
-    type: county
-  - layerId: total-population-municipality
-    type: municipality
-
   defaultGeographyLevel: subregion
 
   sources:
@@ -77,58 +69,67 @@ map:
 
   isPercent: false
 
-  layers:
-  - id: total-population-subregion
+  layerGroups:
+  - id: subregion
     title: "Total Population 2016"
-    type: choropleth
-    source: total-population
-    source-layer: total-population-subregion
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#73efff"
-      - "#0094ff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - 1000000
-      - 2000000
-      - 5000000
-      - 7500000
-  - id: total-population-county
+    legend: total-population-subregion
+    layers:
+    - id: total-population-subregion
+      type: choropleth
+      source: total-population
+      source-layer: total-population-subregion
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#73efff"
+        - "#0094ff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - 1000000
+        - 2000000
+        - 5000000
+        - 7500000
+  - id: county
     title: "Total Population 2016"
-    type: choropleth
-    source: total-population
-    source-layer: total-population-county
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#73efff"
-      - "#0094ff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - 250000
-      - 500000
-      - 750000
-      - 1250000
-  - id: total-population-municipality
+    legend: total-population-county
+    layers:
+    - id: total-population-county
+      type: choropleth
+      source: total-population
+      source-layer: total-population-county
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#73efff"
+        - "#0094ff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - 250000
+        - 500000
+        - 750000
+        - 1250000
+  - id: municipality
     title: "Total Population 2016"
-    type: choropleth
-    source: total-population
-    source-layer: total-population-municipality
-    paintConfig:
-      opacity: 0.6
-      colors:
-      - "#d4f3f7"
-      - "#73efff"
-      - "#0094ff"
-      - "#0058ee"
-      - "#002673"
-      breaks:
-      - 10000
-      - 50000
-      - 100000
-      - 200000
+    legend: total-population-municipality
+    layers:
+    - id: total-population-municipality
+      type: choropleth
+      source: total-population
+      source-layer: total-population-municipality
+      paintConfig:
+        opacity: 0.6
+        colors:
+        - "#d4f3f7"
+        - "#73efff"
+        - "#0094ff"
+        - "#0058ee"
+        - "#002673"
+        breaks:
+        - 10000
+        - 50000
+        - 100000
+        - 200000

--- a/tests/integration/components/legend-box.js
+++ b/tests/integration/components/legend-box.js
@@ -37,9 +37,9 @@ test('it displays toggle from data', function(assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   const toggles = [
-    { layerId: 'map-id-1', type: 'county' },
-    { layerId: 'map-id-1', type: 'subregion' },
-    { layerId: 'map-id-1', type: 'region' },
+    { layerIds: 'map-id-1', type: 'county' },
+    { layerIds: 'map-id-1', type: 'subregion' },
+    { layerIds: 'map-id-1', type: 'region' },
   ];
 
   this.set('toggles', toggles);


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR:

- Refactor all configs, removing `toggles`, and adding `layerGroups` so each map can have several mapboxGL layers displayed simultaneously.
- Adds municipal boundaries and tooltips to the intro map. Closes #89
- Adds logic for hiding legend if no legend is defined in the layerGroup Closes #128
- Adds logic for disabling popups if no `popupColumns` exist in the config. Closes #127 

