### PR TITLE
New prev/next buttons with transition prompt

### DIFF
--- a/app/controllers/map.js
+++ b/app/controllers/map.js
@@ -16,7 +16,7 @@ export default Controller.extend({
 
   @computed('application.model.maps', 'model.slug')
   previousNarrative(maps, currentSlug) {
-    const mapNarratives = maps.filter(map => map.hasNarrative);
+    const mapNarratives = maps.filter(map => map.isLinearNarrative);
     const currentPosition = mapNarratives.findIndex(map => map.slug === currentSlug);
 
     return mapNarratives[currentPosition - 1];
@@ -24,7 +24,7 @@ export default Controller.extend({
 
   @computed('application.model.maps', 'model.slug')
   nextNarrative(maps, currentSlug) {
-    const mapNarratives = maps.filter(map => map.hasNarrative);
+    const mapNarratives = maps.filter(map => map.isLinearNarrative);
     const currentPosition = mapNarratives.findIndex(map => map.slug === currentSlug);
 
     return mapNarratives[currentPosition + 1];

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -53,7 +53,7 @@ $lu-gray: #5F5F60;
 // @include foundation-media-object;
 // @include foundation-off-canvas;
 // @include foundation-orbit;
-@include foundation-pagination;
+// @include foundation-pagination;
 // @include foundation-progress-bar;
 // @include foundation-slider;
 // @include foundation-sticky;

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -118,6 +118,7 @@ body {
   @include breakpoint(large) {
     box-shadow: -4px 0 0 0 rgba(0,0,0,0.1);
     overflow: visible;
+    padding-bottom: rem-calc(150);
   }
 }
 
@@ -129,6 +130,8 @@ body {
 
 .narrative-navigation {
 
+  margin-top: $global-margin*3;
+
   @include breakpoint(large) {
     position: fixed;
     bottom: 0;
@@ -137,9 +140,10 @@ body {
     background-color: $white;
     box-shadow: 0 -2px 0 0 rgba(0,0,0,0.1);
     padding: rem-calc(12);
+    margin-top: 0;
 
-    .pagination {
-      margin: 0;
+    .button {
+      margin: 0 rem-calc(5) 0;
     }
   }
 
@@ -147,6 +151,11 @@ body {
     width: calc(33.333%);
   }
 
+  .narrative-transition-prompt {
+    font-size: rem-calc(14);
+    font-weight: $global-weight-bold;
+    margin-bottom: $global-margin/2;
+  }
 }
 
 .narrative-toggle {

--- a/app/templates/map.hbs
+++ b/app/templates/map.hbs
@@ -25,28 +25,19 @@
 
     {{outlet}}
 
-    {{#if model.hasNarrative}}
-      <nav aria-label="Pagination" class="narrative-navigation">
-        <ul class="pagination text-center">
-          <li class="pagination-previous {{unless previousNarrative 'disabled'}}">
-            {{#if previousNarrative}}
-              {{#link-to 'map' previousNarrative.categorySlug previousNarrative.slug}}
-                {{fa-icon 'arrow-left'}}&nbsp;Previous
-              {{/link-to}}
-            {{else}}
-              {{fa-icon 'arrow-left'}}&nbsp;Previous
-            {{/if}}
-          </li>
-          <li class="pagination-next {{unless nextNarrative 'disabled'}}">
-            {{#if nextNarrative}}
-              {{#link-to 'map' nextNarrative.categorySlug nextNarrative.slug}}
-                Next&nbsp;{{fa-icon 'arrow-right'}}
-              {{/link-to}}
-            {{else}}
-              Next&nbsp;{{fa-icon 'arrow-right'}}
-            {{/if}}
-          </li>
-        </ul>
+    {{#if model.isLinearNarrative}}
+      <nav class="narrative-navigation text-center">
+        {{#if model.transitionPrompt}}
+          <p class="narrative-transition-prompt">{{model.transitionPrompt}}</p>
+        {{/if}}
+
+        {{#link-to 'map' previousNarrative.categorySlug previousNarrative.slug class=(if previousNarrative 'button tiny gray text-orange' 'button tiny gray text-orange disabled')}}
+          {{fa-icon 'arrow-left'}}
+        {{/link-to}}
+
+        {{#link-to 'map' nextNarrative.categorySlug nextNarrative.slug class=(if nextNarrative 'button' 'button disabled')}}
+          Next&nbsp;&nbsp;{{fa-icon 'arrow-right'}}
+        {{/link-to}}
       </nav>
     {{/if}}
 

--- a/app/templates/map.hbs
+++ b/app/templates/map.hbs
@@ -31,11 +31,11 @@
           <p class="narrative-transition-prompt">{{model.transitionPrompt}}</p>
         {{/if}}
 
-        {{#link-to 'map' previousNarrative.categorySlug previousNarrative.slug class=(if previousNarrative 'button tiny gray text-orange' 'button tiny gray text-orange disabled')}}
+        {{#link-to 'map' previousNarrative.categorySlug previousNarrative.slug class=(if previousNarrative 'button tiny gray text-orange pagination-prev' 'button tiny gray text-orange disabled pagination-prev')}}
           {{fa-icon 'arrow-left'}}
         {{/link-to}}
 
-        {{#link-to 'map' nextNarrative.categorySlug nextNarrative.slug class=(if nextNarrative 'button' 'button disabled')}}
+        {{#link-to 'map' nextNarrative.categorySlug nextNarrative.slug class=(if nextNarrative 'button pagination-next' 'button disabled pagination-next')}}
           Next&nbsp;&nbsp;{{fa-icon 'arrow-right'}}
         {{/link-to}}
       </nav>

--- a/cms/meta.yaml
+++ b/cms/meta.yaml
@@ -5,51 +5,54 @@ orderings:
 
   maps:
     - id: intro
-      hasNarrative: true
+      isLinearNarrative: true
       hideFromMenu: true
+      transitionPrompt: Learn about some subject in the next map
 
     # People
     - id: total-population
-      hasNarrative: true
+      isLinearNarrative: true
+      transitionPrompt: Our population is recentralizing...
     - id: population-density
-      hasNarrative: true
+      isLinearNarrative: true
+      transitionPrompt: Learn about some subject in the next map
     - id: population-change
-      hasNarrative: true
+      isLinearNarrative: true
     - id: net-population-change
-      hasNarrative: true
+      isLinearNarrative: true
     - id: foreign-born
-      hasNarrative: true
+      isLinearNarrative: true
     - id: prime-labor-force-gain
-      hasNarrative: true
+      isLinearNarrative: true
 
     # Housing
     - id: total-units
-      hasNarrative: true
+      isLinearNarrative: true
     - id: renter-owner
-      hasNarrative: true
+      isLinearNarrative: true
     - id: units-permitted
-      hasNarrative: true
+      isLinearNarrative: true
     - id: multifamily-permitted
-      hasNarrative: true
+      isLinearNarrative: true
 
     # Jobs
     - id: total-employment
-      hasNarrative: true
+      isLinearNarrative: true
     - id: office-employment
-      hasNarrative: true
+      isLinearNarrative: true
     - id: institutional-employment
-      hasNarrative: true
+      isLinearNarrative: true
     - id: industrial-employment
-      hasNarrative: true
+      isLinearNarrative: true
     - id: localserve-employment
-      hasNarrative: true
+      isLinearNarrative: true
     - id: private-employment-change
-      hasNarrative: true
+      isLinearNarrative: true
 
     # Balance
     - id: balance-housjobs00
-      hasNarrative: true
+      isLinearNarrative: true
     - id: balance-housjobs16
-      hasNarrative: true
+      isLinearNarrative: true
     - id: balance-housjobs0016
-      hasNarrative: true
+      isLinearNarrative: true

--- a/tests/acceptance/click-through-routes-test.js
+++ b/tests/acceptance/click-through-routes-test.js
@@ -23,10 +23,9 @@ test('index redirects to welcome/intro', function(assert) {
 
 test('user can click "next" from intro', function(assert) {
   visit('/');
-  click('.pagination-next a');
+  click('.pagination-next');
 
   andThen(function() {
     assert.equal(currentURL().indexOf('/welcome/intro'), -1);
   });
 });
-

--- a/tests/unit/utils/structure-and-order-cms-test.js
+++ b/tests/unit/utils/structure-and-order-cms-test.js
@@ -20,15 +20,15 @@ const testData = {
          "maps":[
             {
                "id":"housing-3",
-               "hasNarrative":true
+               "isLinearNarrative":true
             },
             {
                "id":"housing-2",
-               "hasNarrative":true
+               "isLinearNarrative":true
             },
             {
                "id":"housing-1",
-               "hasNarrative":true
+               "isLinearNarrative":true
             },
          ]
       }


### PR DESCRIPTION
This PR…
- Refactors the narrative's previous/next buttons with a better UI and call-to-action
- The `hasNarrative` config variable is renamed `isLinearNarrative` (because every map _has_ a narrative, but only some are included in the linear previous/next flow)
- Removes the now-unused Foundation Pagination CSS
- Bigger next button, smaller previous button sans text (moving forward in the narrative is the primary action) 
- Adds a `transitionPrompt` variable to maps in `meta.yaml` which allows for a phrase to act as a call-to-action for clicking the next button
- Adjusts the layout of narrative navigation, giving more padding where needed on various screen sizes

Closes #152. 
