### PR TITLE
update introduction config to use state-based fill color

### DIFF
--- a/cms/maps/introduction.yaml
+++ b/cms/maps/introduction.yaml
@@ -23,11 +23,11 @@ map:
       type: cartovector
       source-layers:
       - id: empty-polygons-subregion
-        sql: SELECT the_geom_webmercator, geoid, (cartodb_id % 5) AS color, name FROM region_subregion_v0
+        sql: SELECT the_geom_webmercator, geoid, statefp, name FROM region_subregion_v0
       - id: empty-polygons-county
-        sql: SELECT the_geom_webmercator, geoid, (cartodb_id % 5) AS color, name FROM region_county_v0
+        sql: SELECT the_geom_webmercator, geoid, LEFT(geoid::text, 2)::integer AS statefp, name FROM region_county_v0
       - id: empty-polygons-municipality
-        sql: SELECT the_geom_webmercator, geoid, (cartodb_id % 5) AS color, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+        sql: SELECT the_geom_webmercator, geoid, LEFT(stcoid::text, 2)::integer AS statefp, name FROM region_municipality_v0 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   layerGroups:
   - id: subregion
@@ -44,17 +44,13 @@ map:
         fill-color:
         - match
         - - get
-          - color
-        - 0
-        - rgba(67, 114, 222, 1)
-        - 1
-        - rgba(56, 98, 193, 1)
-        - 2
-        - rgba(48, 85, 167, 1)
-        - 3
-        - rgba(41, 72, 142, 1)
-        - 4
-        - rgba(34, 60, 119, 1)
+          - statefp
+        - 34
+        - "#069C65"
+        - 36
+        - "#33B6BD"
+        - 9
+        - "#E0C80B"
         - "#FFFFFF"
         fill-antialias: true
   - id: county
@@ -71,17 +67,13 @@ map:
         fill-color:
         - match
         - - get
-          - color
-        - 0
-        - rgba(67, 114, 222, 1)
-        - 1
-        - rgba(56, 98, 193, 1)
-        - 2
-        - rgba(48, 85, 167, 1)
-        - 3
-        - rgba(41, 72, 142, 1)
-        - 4
-        - rgba(34, 60, 119, 1)
+          - statefp
+        - 34
+        - "#069C65"
+        - 36
+        - "#33B6BD"
+        - 9
+        - "#E0C80B"
         - "#FFFFFF"
         fill-antialias: true
   - id: municipality
@@ -99,16 +91,12 @@ map:
         fill-color:
         - match
         - - get
-          - color
-        - 0
-        - rgba(67, 114, 222, 1)
-        - 1
-        - rgba(56, 98, 193, 1)
-        - 2
-        - rgba(48, 85, 167, 1)
-        - 3
-        - rgba(41, 72, 142, 1)
-        - 4
-        - rgba(34, 60, 119, 1)
+          - statefp
+        - 34
+        - "#069C65"
+        - 36
+        - "#33B6BD"
+        - 9
+        - "#E0C80B"
         - "#FFFFFF"
         fill-antialias: true


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR modifies the introduction choropleth to use `statefp` for fill-color, visualizing each geometry by state.

Closes #164
