### PR TITLE
Popup and Legend formatter conditions

### DIFF
--- a/app/components/legend-box.js
+++ b/app/components/legend-box.js
@@ -14,6 +14,7 @@ function getChoroplethRows(layerConfig, isPercent, isChangeMeasurement, isRatio)
     if (isRatio) formatter = '0.00';
     if (isChangeMeasurement) formatter = '+0,0';
     if (isPercent && isChangeMeasurement) formatter = '+0.0%';
+    if (isRatio && isChangeMeasurement) formatter = '+0.00';
 
     return numeral(value).format(formatter);
   };

--- a/app/utils/build-popup-content.js
+++ b/app/utils/build-popup-content.js
@@ -20,7 +20,8 @@ export default function buildPopupContent(data, geographyLevel, popupColumns, is
         if (isPercent) formattedValue = numeral(value).format('0,0%');
         if (isRatio) formattedValue = numeral(value).format('0.00');
         if (isChangeMeasurement) formattedValue = numeral(value).format('+0,0');
-        if (isPercent && isChangeMeasurement) formattedValue = '+0.0%';
+        if (isPercent && isChangeMeasurement) formattedValue = numeral(value).format('+0.0%');
+        if (isRatio && isChangeMeasurement) formattedValue = numeral(value).format('+0.00');
         if (isChangeMeasurement && isMOE) formattedValue = `±${numeral(value).format('0,0')}`;
       }
 


### PR DESCRIPTION
This PR adds new conditions to the Legend and Popup so that they can be both `isRatio` && `isChangeMeasurement`, per @daragoldberg (don't think there's an associated issue). 