### PR TITLE
use-aliased-data

### DIFF
--- a/app/supporting-layers/rail.js
+++ b/app/supporting-layers/rail.js
@@ -5,11 +5,11 @@ export default {
     'source-layers': [
       {
         id: 'rail-lines',
-        sql: 'SELECT the_geom_webmercator FROM region_rail_lines_v0',
+        sql: 'SELECT the_geom_webmercator FROM region_rail_lines',
       },
       {
         id: 'rail-stops',
-        sql: 'SELECT the_geom_webmercator FROM region_rail_stops_v0',
+        sql: 'SELECT the_geom_webmercator FROM region_rail_stops',
       },
     ],
   },

--- a/app/utils/get-popup-sql.js
+++ b/app/utils/get-popup-sql.js
@@ -18,13 +18,13 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
 
   SQLArray.push(`
     SELECT 'region' as geomtype, null as islitown, null as houptest, null as iscomnycwork, null as iscomnycres, 'Total Metro Area' as name ${getPopupValue('region')}
-    FROM region_region_v2
+    FROM region_region
   `);
 
   if (getPopupValue('subregion')) {
     SQLArray.push(`
       SELECT 'subregion' as geomtype, null as islitown, null as houptest, null as iscomnycwork, null as iscomnycres, name as name ${getPopupValue('subregion')}
-      FROM region_subregion_v2
+      FROM region_subregion
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);
   }
@@ -34,7 +34,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
   if (getPopupValue('county')) {
     SQLArray.push(`
       SELECT 'county' as geomtype, null as islitown, null as houptest, iscomnycwork, iscomnycres, name as name ${getPopupValue('county')}
-      FROM region_county_v2
+      FROM region_county
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);
   }
@@ -44,7 +44,7 @@ export default function getPopupSQL(lngLat = { lng: 0, lat: 0 }, mapConfig = { p
   if (getPopupValue('municipality')) {
     SQLArray.push(`
       SELECT 'municipality' as geomtype, islitown, houptest, null as iscomnycwork, null as iscomnycres, namelsad as name ${getPopupValue('municipality')}
-      FROM region_municipality_v1
+      FROM region_municipality
       WHERE ST_Intersects(the_geom, ST_SetSRID(ST_Point(${lng}, ${lat}), 4326))
     `);
   }

--- a/cms/maps/balance-housjobs00.yaml
+++ b/cms/maps/balance-housjobs00.yaml
@@ -32,9 +32,9 @@ map:
     type: cartovector
     source-layers:
     - id: balance-housjobs00-subregion
-      sql: SELECT the_geom_webmercator, geoid, balhj00 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, balhj00 as value, name FROM region_subregion
     - id: balance-housjobs00-county
-      sql: SELECT the_geom_webmercator, geoid, balhj00 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, balhj00 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: balhj

--- a/cms/maps/balance-housjobs0016.yaml
+++ b/cms/maps/balance-housjobs0016.yaml
@@ -31,9 +31,9 @@ map:
     type: cartovector
     source-layers:
     - id: balance-housjobs0016-subregion
-      sql: SELECT the_geom_webmercator, geoid, balhj0016 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, balhj0016 as value, name FROM region_subregion
     - id: balance-housjobs0016-county
-      sql: SELECT the_geom_webmercator, geoid, balhj0016 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, balhj0016 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: balhj0016

--- a/cms/maps/balance-housjobs16.yaml
+++ b/cms/maps/balance-housjobs16.yaml
@@ -32,9 +32,9 @@ map:
     type: cartovector
     source-layers:
     - id: balance-housjobs16-subregion
-      sql: SELECT the_geom_webmercator, geoid, balhj16 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, balhj16 as value, name FROM region_subregion
     - id: balance-housjobs16-county
-      sql: SELECT the_geom_webmercator, geoid, balhj16 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, balhj16 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: balhj16

--- a/cms/maps/commuting-mode-mnworkerres.yaml
+++ b/cms/maps/commuting-mode-mnworkerres.yaml
@@ -23,7 +23,7 @@ map:
       type: cartovector
       source-layers:
       - id: mode-mnworkerres-tract
-        sql: SELECT the_geom_webmercator, category FROM region_commode_mnworkres_dotdensity_v0 ORDER BY random()
+        sql: SELECT the_geom_webmercator, category FROM region_commode_mnworkres_dotdensity ORDER BY random()
       - id: empty-polygons-subregion
         sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
       - id: empty-polygons-county

--- a/cms/maps/commuting-mode-mnworkerres.yaml
+++ b/cms/maps/commuting-mode-mnworkerres.yaml
@@ -25,9 +25,9 @@ map:
       - id: mode-mnworkerres-tract
         sql: SELECT the_geom_webmercator, category FROM region_commode_mnworkres_dotdensity_v0 ORDER BY random()
       - id: empty-polygons-subregion
-        sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+        sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
       - id: empty-polygons-county
-        sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
+        sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
 
     popupColumns:
     - id: cmncar

--- a/cms/maps/commuting-mode-nonmnworkerres.yaml
+++ b/cms/maps/commuting-mode-nonmnworkerres.yaml
@@ -23,7 +23,7 @@ map:
     type: cartovector
     source-layers:
     - id: mode-nonmnworkerres-tract
-      sql: SELECT the_geom_webmercator, category FROM region_commode_nonmnworkres_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, category FROM region_commode_nonmnworkres_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
       sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county

--- a/cms/maps/commuting-mode-nonmnworkerres.yaml
+++ b/cms/maps/commuting-mode-nonmnworkerres.yaml
@@ -25,9 +25,9 @@ map:
     - id: mode-nonmnworkerres-tract
       sql: SELECT the_geom_webmercator, category FROM region_commode_nonmnworkres_dotdensity_v0 ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
 
 
   popupColumns:

--- a/cms/maps/commuting-mode-nycresidentwork.yaml
+++ b/cms/maps/commuting-mode-nycresidentwork.yaml
@@ -25,9 +25,9 @@ map:
     - id: mode-nycresidentwork-tract
       sql: SELECT the_geom_webmercator, category FROM region_commode_nycreswork_dotdensity_v0 ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county-iscomnycwork
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('36119', '36079', '36105', '36111') ##test "IsComNYCRes <> FALSE"
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('36119', '36079', '36105', '36111') ##test "IsComNYCRes <> FALSE"
 
 
   popupColumns:

--- a/cms/maps/commuting-mode-nycresidentwork.yaml
+++ b/cms/maps/commuting-mode-nycresidentwork.yaml
@@ -23,7 +23,7 @@ map:
     type: cartovector
     source-layers:
     - id: mode-nycresidentwork-tract
-      sql: SELECT the_geom_webmercator, category FROM region_commode_nycreswork_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, category FROM region_commode_nycreswork_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
       sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county-iscomnycwork

--- a/cms/maps/commuting-total-nycresidentwork.yaml
+++ b/cms/maps/commuting-total-nycresidentwork.yaml
@@ -25,9 +25,9 @@ map:
     - id: total-nycresidentwork-tract
       sql: SELECT the_geom_webmercator, category FROM region_comtot_nycreswork_dotdensity_v0 ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county-iscomnycwork
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('36119', '36079', '36105', '36111') ##test "IsComNYCRes <> FALSE"
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('36119', '36079', '36105', '36111') ##test "IsComNYCRes <> FALSE"
 
   popupColumns:
   - id: crnyctot

--- a/cms/maps/commuting-total-nycresidentwork.yaml
+++ b/cms/maps/commuting-total-nycresidentwork.yaml
@@ -23,7 +23,7 @@ map:
     type: cartovector
     source-layers:
     - id: total-nycresidentwork-tract
-      sql: SELECT the_geom_webmercator, category FROM region_comtot_nycreswork_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, category FROM region_comtot_nycreswork_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
       sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county-iscomnycwork

--- a/cms/maps/commuting-total-nycworkerchange.yaml
+++ b/cms/maps/commuting-total-nycworkerchange.yaml
@@ -25,9 +25,9 @@ map:
     type: cartovector
     source-layers:
     - id: total-nycworkerchange-subregion
-      sql: SELECT the_geom_webmercator, geoid, cwnyc0017 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, cwnyc0017 as value, name FROM region_subregion
     - id: total-nycworkerchange-county
-      sql: SELECT the_geom_webmercator, geoid, cwnyc0017 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
+      sql: SELECT the_geom_webmercator, geoid, cwnyc0017 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
 
 
   popupColumns:

--- a/cms/maps/commuting-total-nycworkerres.yaml
+++ b/cms/maps/commuting-total-nycworkerres.yaml
@@ -29,9 +29,9 @@ map:
     - id: total-nycworkerres-tract
       sql: SELECT the_geom_webmercator, category FROM region_comtot_nycworkerres_dotdensity_v0 ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '36105','36111') ##test "IsComNYCWork <> FALSE"
 
   popupColumns:
 

--- a/cms/maps/commuting-total-nycworkerres.yaml
+++ b/cms/maps/commuting-total-nycworkerres.yaml
@@ -27,7 +27,7 @@ map:
     type: cartovector
     source-layers:
     - id: total-nycworkerres-tract
-      sql: SELECT the_geom_webmercator, category FROM region_comtot_nycworkerres_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, category FROM region_comtot_nycworkerres_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
       sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county

--- a/cms/maps/housing-multifamily-permitted.yaml
+++ b/cms/maps/housing-multifamily-permitted.yaml
@@ -21,17 +21,17 @@ map:
     type: cartovector
     source-layers:
     - id: multifamily-permitted-subregion
-      sql: SELECT the_geom_webmercator, geoid, houps1016 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, houps1016 as value, name FROM region_subregion
     - id: multifamily-permitted-county
-      sql: SELECT the_geom_webmercator, geoid, houps1016 as value, name FROM region_county_v2
+      sql: SELECT the_geom_webmercator, geoid, houps1016 as value, name FROM region_county
     - id: multifamily-permitted-municipality
-      sql: SELECT the_geom_webmercator, random_value FROM region_unittype_dotdensity_v2 ORDER BY random()
+      sql: SELECT the_geom_webmercator, random_value FROM region_unittype_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE houptest <> 'N'
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE houptest <> 'N'
 
   popupColumns:
   - id: houps

--- a/cms/maps/housing-renter-owner.yaml
+++ b/cms/maps/housing-renter-owner.yaml
@@ -18,13 +18,13 @@ map:
     type: cartovector
     source-layers:
     - id: renter-owner-tract
-      sql: SELECT the_geom_webmercator, random_value FROM region_tenure_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, random_value FROM region_tenure_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: owner

--- a/cms/maps/housing-total-units.yaml
+++ b/cms/maps/housing-total-units.yaml
@@ -18,11 +18,11 @@ map:
     type: cartovector
     source-layers:
     - id: total-units-subregion
-      sql: SELECT the_geom_webmercator, geoid, houa16 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, houa16 as value, name FROM region_subregion
     - id: total-units-county
-      sql: SELECT the_geom_webmercator, geoid, houa16 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, houa16 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: total-units-municipality
-      sql: SELECT the_geom_webmercator, geoid, hou16 as value, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, hou16 as value, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: totalunits

--- a/cms/maps/housing-units-by-structure.yaml
+++ b/cms/maps/housing-units-by-structure.yaml
@@ -21,13 +21,13 @@ map:
     type: cartovector
     source-layers:
     - id: units-by-structure-municipality
-      sql: SELECT the_geom_webmercator, category FROM region_units_by_structure_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, category FROM region_units_by_structure_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE WHERE geoid NOT IN ('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE WHERE geoid NOT IN ('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: hous

--- a/cms/maps/housing-units-permitted.yaml
+++ b/cms/maps/housing-units-permitted.yaml
@@ -20,11 +20,11 @@ map:
     type: cartovector
     source-layers:
     - id: units-permitted-subregion
-      sql: SELECT the_geom_webmercator, geoid, houp1016 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, houp1016 as value, name FROM region_subregion
     - id: units-permitted-county
-      sql: SELECT the_geom_webmercator, geoid, houp1016 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, houp1016 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: units-permitted-municipality
-      sql: SELECT the_geom_webmercator, geoid, houp1016 as value, name FROM region_municipality_v1 WHERE houptest <> 'N'
+      sql: SELECT the_geom_webmercator, geoid, houp1016 as value, name FROM region_municipality WHERE houptest <> 'N'
 
   popupColumns:
   - id: houp

--- a/cms/maps/introduction.yaml
+++ b/cms/maps/introduction.yaml
@@ -31,11 +31,11 @@ map:
       type: cartovector
       source-layers:
       - id: empty-polygons-subregion
-        sql: SELECT the_geom_webmercator, geoid, statefp || '-' || (cartodb_id % 5) AS styleid, name FROM region_subregion_v2
+        sql: SELECT the_geom_webmercator, geoid, statefp || '-' || (cartodb_id % 5) AS styleid, name FROM region_subregion
       - id: empty-polygons-county
-        sql: SELECT the_geom_webmercator, geoid, LEFT(geoid::text, 2) || '-' || (cartodb_id % 5) AS styleid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+        sql: SELECT the_geom_webmercator, geoid, LEFT(geoid::text, 2) || '-' || (cartodb_id % 5) AS styleid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
       - id: empty-polygons-municipality
-        sql: SELECT the_geom_webmercator, geoid, LEFT(stcoid::text, 2) || '-' || (cartodb_id % 5) AS styleid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+        sql: SELECT the_geom_webmercator, geoid, LEFT(stcoid::text, 2) || '-' || (cartodb_id % 5) AS styleid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   layerGroups:
   - id: subregion

--- a/cms/maps/jobs-employment-by-sector.yaml
+++ b/cms/maps/jobs-employment-by-sector.yaml
@@ -23,13 +23,13 @@ map:
     type: cartovector
     source-layers:
     - id: employment-by-sector-tract
-      sql: SELECT the_geom_webmercator, category FROM region_employment_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, category FROM region_employment_dotdensity ORDER BY random()
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emoff

--- a/cms/maps/jobs-industrial-employment-change.yaml
+++ b/cms/maps/jobs-industrial-employment-change.yaml
@@ -19,9 +19,9 @@ map:
     type: cartovector
     source-layers:
     - id: industrial-employment-change-subregion
-      sql: SELECT the_geom_webmercator, geoid, emind0816 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, emind0816 as value, name FROM region_subregion
     - id: industrial-employment-change-county
-      sql: SELECT the_geom_webmercator, geoid, emind0816 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, emind0816 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: empr

--- a/cms/maps/jobs-industrial-employment.yaml
+++ b/cms/maps/jobs-industrial-employment.yaml
@@ -19,13 +19,13 @@ map:
     type: cartovector
     source-layers:
     - id: industrial-employment-tract
-      sql: SELECT the_geom_webmercator, emind15 as value FROM region_censustract_industrial_dotdensity_v0
+      sql: SELECT the_geom_webmercator, emind15 as value FROM region_censustract_industrial_dotdensity
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '361035000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '361035000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emind

--- a/cms/maps/jobs-institutional-employment-change.yaml
+++ b/cms/maps/jobs-institutional-employment-change.yaml
@@ -21,9 +21,9 @@ map:
     type: cartovector
     source-layers:
     - id: institutional-employment-change-subregion
-      sql: SELECT the_geom_webmercator, geoid, emprins0816 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, emprins0816 as value, name FROM region_subregion
     - id: institutional-employment-change-county
-      sql: SELECT the_geom_webmercator, geoid, emprins0816 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, emprins0816 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: empr

--- a/cms/maps/jobs-institutional-employment.yaml
+++ b/cms/maps/jobs-institutional-employment.yaml
@@ -18,13 +18,13 @@ map:
     type: cartovector
     source-layers:
     - id: institutional-employment-tract
-      sql: SELECT the_geom_webmercator, emins15 as value FROM region_censustract_institution_dotdensity_v0
+      sql: SELECT the_geom_webmercator, emins15 as value FROM region_censustract_institution_dotdensity
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '361035000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '361035000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emins

--- a/cms/maps/jobs-localserve-employment-change.yaml
+++ b/cms/maps/jobs-localserve-employment-change.yaml
@@ -19,9 +19,9 @@ map:
     type: cartovector
     source-layers:
     - id: localserve-employment-change-subregion
-      sql: SELECT the_geom_webmercator, geoid, emser0816 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, emser0816 as value, name FROM region_subregion
     - id: localserve-employment-change-county
-      sql: SELECT the_geom_webmercator, geoid, emser0816 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, emser0816 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: empr

--- a/cms/maps/jobs-localserve-employment.yaml
+++ b/cms/maps/jobs-localserve-employment.yaml
@@ -18,13 +18,13 @@ map:
     type: cartovector
     source-layers:
     - id: localserve-employment-tract
-      sql: SELECT the_geom_webmercator, emser15 as value FROM region_censustract_localserv_dotdensity_v0
+      sql: SELECT the_geom_webmercator, emser15 as value FROM region_censustract_localserv_dotdensity
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '361035000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '361035000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emser

--- a/cms/maps/jobs-office-employment-change.yaml
+++ b/cms/maps/jobs-office-employment-change.yaml
@@ -19,9 +19,9 @@ map:
     type: cartovector
     source-layers:
     - id: office-employment-change-subregion
-      sql: SELECT the_geom_webmercator, geoid, emoff0816 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, emoff0816 as value, name FROM region_subregion
     - id: office-employment-change-county
-      sql: SELECT the_geom_webmercator, geoid, emoff0816 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, emoff0816 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: empr

--- a/cms/maps/jobs-office-employment.yaml
+++ b/cms/maps/jobs-office-employment.yaml
@@ -19,13 +19,13 @@ map:
     type: cartovector
     source-layers:
     - id: office-employment-tract
-      sql: SELECT the_geom_webmercator, emoff15 as value FROM region_censustract_office_dotdensity_v0
+      sql: SELECT the_geom_webmercator, emoff15 as value FROM region_censustract_office_dotdensity
     - id: empty-polygons-subregion
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_subregion
     - id: empty-polygons-county
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emoff

--- a/cms/maps/jobs-private-employment-change.yaml
+++ b/cms/maps/jobs-private-employment-change.yaml
@@ -21,9 +21,9 @@ map:
     type: cartovector
     source-layers:
     - id: private-employment-change-subregion
-      sql: SELECT the_geom_webmercator, geoid, empr0816 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, empr0816 as value, name FROM region_subregion
     - id: private-employment-change-county
-      sql: SELECT the_geom_webmercator, geoid, empr0816 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, empr0816 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: empr

--- a/cms/maps/jobs-total-employment.yaml
+++ b/cms/maps/jobs-total-employment.yaml
@@ -20,11 +20,11 @@ map:
     type: cartovector
     source-layers:
     - id: total-employment-subregion
-      sql: SELECT the_geom_webmercator, geoid, emtot16 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, emtot16 as value, name FROM region_subregion
     - id: total-employment-county
-      sql: SELECT the_geom_webmercator, geoid, emtot16 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, emtot16 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: total-employment-municipality
-      sql: SELECT the_geom_webmercator, geoid, emtot15 as value, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, emtot15 as value, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: emptot

--- a/cms/maps/people-foreign-born.yaml
+++ b/cms/maps/people-foreign-born.yaml
@@ -18,11 +18,11 @@ map:
     type: cartovector
     source-layers:
     - id: foreign-born-subregion
-      sql: SELECT the_geom_webmercator, geoid, popfbp16 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, popfbp16 as value, name FROM region_subregion
     - id: foreign-born-county
-      sql: SELECT the_geom_webmercator, geoid, popfbp16 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, popfbp16 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: foreign-born-municipality
-      sql: SELECT the_geom_webmercator, geoid, popfbp16 as value, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, popfbp16 as value, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: count

--- a/cms/maps/people-labor-force-gain.yaml
+++ b/cms/maps/people-labor-force-gain.yaml
@@ -23,7 +23,7 @@ map:
     - id: labor-force-gain-county
       sql: SELECT the_geom_webmercator, geoid, lf0016 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: labor-force-gain-municipality
-      sql: SELECT the_geom_webmercator, lf0016 as value FROM region_municipality_lf0016_dotdensity_v0 ORDER BY random()
+      sql: SELECT the_geom_webmercator, lf0016 as value FROM region_municipality_lf0016_dotdensity ORDER BY random()
     - id: empty-polygons-municipality
       sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 

--- a/cms/maps/people-labor-force-gain.yaml
+++ b/cms/maps/people-labor-force-gain.yaml
@@ -19,13 +19,13 @@ map:
     type: cartovector
     source-layers:
     - id: labor-force-gain-subregion
-      sql: SELECT the_geom_webmercator, geoid, lf0016 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, lf0016 as value, name FROM region_subregion
     - id: labor-force-gain-county
-      sql: SELECT the_geom_webmercator, geoid, lf0016 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, lf0016 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: labor-force-gain-municipality
       sql: SELECT the_geom_webmercator, lf0016 as value FROM region_municipality_lf0016_dotdensity_v0 ORDER BY random()
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: pop

--- a/cms/maps/people-net-population-change.yaml
+++ b/cms/maps/people-net-population-change.yaml
@@ -18,13 +18,13 @@ map:
     type: cartovector
     source-layers:
     - id: net-population-change-subregion
-      sql: SELECT the_geom_webmercator, geoid, pop1016 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, pop1016 as value, name FROM region_subregion
     - id: net-population-change-county
-      sql: SELECT the_geom_webmercator, geoid, pop1016 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, pop1016 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: net-population-change-municipality-dotdensity
-      sql: SELECT the_geom_webmercator, popa1016 FROM region_popa1016_dotdensity_v1 ORDER BY random()
+      sql: SELECT the_geom_webmercator, popa1016 FROM region_popa1016_dotdensity ORDER BY random()
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: change

--- a/cms/maps/people-population-change.yaml
+++ b/cms/maps/people-population-change.yaml
@@ -19,9 +19,9 @@ map:
     type: cartovector
     source-layers:
     - id: population-change-subregion
-      sql: SELECT the_geom_webmercator, geoid, popp1016 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, popp1016 as value, name FROM region_subregion
     - id: population-change-county
-      sql: SELECT the_geom_webmercator, geoid, popp1016 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, popp1016 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
 
   popupColumns:
   - id: change

--- a/cms/maps/people-population-density.yaml
+++ b/cms/maps/people-population-density.yaml
@@ -19,11 +19,11 @@ map:
     type: cartovector
     source-layers:
     - id: population-density-subregion
-      sql: SELECT the_geom_webmercator, geoid, popepd16 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, popepd16 as value, name FROM region_subregion
     - id: population-density-county
-      sql: SELECT the_geom_webmercator, geoid, popepd16 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, popepd16 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: population-density-municipality
-      sql: SELECT the_geom_webmercator, geoid, popaden16 as value, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, popaden16 as value, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: popdens

--- a/cms/maps/people-prime-labor-force-gain.yaml
+++ b/cms/maps/people-prime-labor-force-gain.yaml
@@ -21,13 +21,13 @@ map:
     type: cartovector
     source-layers:
     - id: prime-labor-force-gain-subregion
-      sql: SELECT the_geom_webmercator, geoid, lfpw0016 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, lfpw0016 as value, name FROM region_subregion
     - id: prime-labor-force-gain-county
-      sql: SELECT the_geom_webmercator, geoid, lfpw0016 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, lfpw0016 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: prime-labor-force-gain-municipality
-      sql: SELECT the_geom_webmercator, lfpw0016 as value FROM region_lfpw0016_dotdensity_v1 ORDER BY random()
+      sql: SELECT the_geom_webmercator, lfpw0016 as value FROM region_lfpw0016_dotdensity ORDER BY random()
     - id: empty-polygons-municipality
-      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality_v1 WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
+      sql: SELECT the_geom_webmercator, geoid, name FROM region_municipality WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:
   - id: pop

--- a/cms/maps/people-total-population.yaml
+++ b/cms/maps/people-total-population.yaml
@@ -19,13 +19,13 @@ map:
     type: cartovector
     source-layers:
     - id: total-population-subregion
-      sql: SELECT the_geom_webmercator, geoid, popep16 as value, name FROM region_subregion_v2
+      sql: SELECT the_geom_webmercator, geoid, popep16 as value, name FROM region_subregion
     - id: total-population-county
-      sql: SELECT the_geom_webmercator, geoid, popep16 as value, name FROM region_county_v2 WHERE geoid NOT IN ('3607936119', '3610536111')
+      sql: SELECT the_geom_webmercator, geoid, popep16 as value, name FROM region_county WHERE geoid NOT IN ('3607936119', '3610536111')
     - id: total-population-municipality
       sql: |
         SELECT the_geom_webmercator, geoid, popa16 as value, name
-        FROM region_municipality_v1
+        FROM region_municipality
         WHERE geoid NOT IN('3605934000', '3605953000', '3605956000', '3610304000', '3610310000', '3610322194', '3610337000', '3610338000', '3610361984', '3610366839', '3610368000', '3610368473', '3610369463')
 
   popupColumns:

--- a/cms/pages/about.yaml
+++ b/cms/pages/about.yaml
@@ -178,17 +178,17 @@ sidebar:
 
     Data are available by geography as shapefiles or comma separated value files. Metadata files include variable definitions and data sources. Please check back for periodic updates.
 
-    - **Region:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=region&q=SELECT%20%2A%20FROM%20region_region_v2&format=SHP),
-    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_region_v2_table&format=CSV),
+    - **Region:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=region&q=SELECT%20%2A%20FROM%20region_region&format=SHP),
+    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_region_table&format=CSV),
     [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_region_meta_v2&format=CSV)
-    - **Subregion:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=subregion&q=SELECT%20%2A%20FROM%20region_subregion_v2&format=SHP),
-    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_subregion_v2_table&format=CSV),
+    - **Subregion:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=subregion&q=SELECT%20%2A%20FROM%20region_subregion&format=SHP),
+    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_subregion_table&format=CSV),
     [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=subregion&q=SELECT%20%2A%20FROM%20region_subregion_meta_v2&format=CSV)
-    - **County:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=county&q=SELECT%20%2A%20FROM%20region_county_v2&format=SHP),
-    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_county_v2_table&format=CSV),
+    - **County:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=county&q=SELECT%20%2A%20FROM%20region_county&format=SHP),
+    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_county_table&format=CSV),
     [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=county&q=SELECT%20%2A%20FROM%20region_county_meta_v2&format=CSV)
-    - **Municipality:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=municipality&q=SELECT%20%2A%20FROM%20region_municipality_v1&format=SHP),
-    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_municipality_v1_table&format=CSV),
+    - **Municipality:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=municipality&q=SELECT%20%2A%20FROM%20region_municipality&format=SHP),
+    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_municipality_table&format=CSV),
     [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=municipality&q=SELECT%20%2A%20FROM%20region_municipality_meta_v0&format=CSV)
     - **Census Tract:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=region&q=SELECT%20%2A%20FROM%20region_censustract_v1&format=SHP),
     [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_censustract_v1_table&format=CSV),

--- a/cms/pages/about.yaml
+++ b/cms/pages/about.yaml
@@ -180,19 +180,19 @@ sidebar:
 
     - **Region:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=region&q=SELECT%20%2A%20FROM%20region_region&format=SHP),
     [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_region_table&format=CSV),
-    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_region_meta_v2&format=CSV)
+    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_region_meta&format=CSV)
     - **Subregion:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=subregion&q=SELECT%20%2A%20FROM%20region_subregion&format=SHP),
     [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_subregion_table&format=CSV),
-    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=subregion&q=SELECT%20%2A%20FROM%20region_subregion_meta_v2&format=CSV)
+    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=subregion&q=SELECT%20%2A%20FROM%20region_subregion_meta&format=CSV)
     - **County:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=county&q=SELECT%20%2A%20FROM%20region_county&format=SHP),
     [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_county_table&format=CSV),
-    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=county&q=SELECT%20%2A%20FROM%20region_county_meta_v2&format=CSV)
+    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=county&q=SELECT%20%2A%20FROM%20region_county_meta&format=CSV)
     - **Municipality:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=municipality&q=SELECT%20%2A%20FROM%20region_municipality&format=SHP),
     [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_municipality_table&format=CSV),
-    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=municipality&q=SELECT%20%2A%20FROM%20region_municipality_meta_v0&format=CSV)
-    - **Census Tract:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=region&q=SELECT%20%2A%20FROM%20region_censustract_v1&format=SHP),
-    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_censustract_v1_table&format=CSV),
-    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=censustract&q=SELECT%20%2A%20FROM%20region_censustract_meta_v1&format=CSV)
+    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=municipality&q=SELECT%20%2A%20FROM%20region_municipality_meta&format=CSV)
+    - **Census Tract:** [Shapefile](https://planninglabs.carto.com/api/v2/sql?filename=region&q=SELECT%20%2A%20FROM%20region_censustract&format=SHP),
+    [CSV](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=region&q=SELECT%20%2A%20FROM%20region_censustract_table&format=CSV),
+    [Metadata](https://planninglabs.carto.com/api/v2/sql?skipfields=the_geom&filename=censustract&q=SELECT%20%2A%20FROM%20region_censustract_meta&format=CSV)
 
     _Last updated on February 5, 2019_
 


### PR DESCRIPTION
This PR updates Carto queries to query from aliased views of the latest dataset version. This reduces data maintenance overhead (now we only need to redefine the view when we get a new data version instead of find/replacing the table name throughout the code base) and makes this app match data view references used in all our other apps.

Related to https://github.com/NYCPlanning/labs-layers-api/pull/124