### PR TITLE
setting node version in netlify toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,7 @@
 [build]
 command = "yarn build --environment=staging"
+environment = { NODE_VERSION = "8.11.3" }
 
 [context.master]
 command = "yarn build --environment=production"
+environment = { NODE_VERSION = "8.11.3" }


### PR DESCRIPTION

This PR updates the netlify.toml to set a node version explicitly

Closes AB#4917
